### PR TITLE
Add support for tenant header

### DIFF
--- a/src/DefaultRESTClient.ts
+++ b/src/DefaultRESTClient.ts
@@ -49,6 +49,21 @@ export default class DefaultRESTClient implements IRESTClient {
   }
 
   /**
+   * Sets the authorization header using a key
+   *
+   * @param {string} tenantId The value of the X-FusionAuth-TenantId header.
+   * @returns {DefaultRESTClient}
+   */
+  withTenantId(tenantId): DefaultRESTClient {
+    if (tenantId === null || typeof tenantId === 'undefined') {
+      return this;
+    }
+
+    this.withHeader('X-FusionAuth-TenantId', tenantId);
+    return this;
+  }
+
+  /**
    * Adds a segment to the request uri
    */
   withUriSegment(segment): DefaultRESTClient {

--- a/src/FusionAuthClient.ts
+++ b/src/FusionAuthClient.ts
@@ -23,7 +23,7 @@ export class FusionAuthClient {
 
   public clientBuilder: IRESTClientBuilder = new DefaultRESTClientBuilder();
 
-  constructor(public apiKey: string, public host: string) {
+  constructor(public apiKey: string, public host: string, public tenantId?: string) {
   }
 
   /**
@@ -2531,6 +2531,15 @@ export class FusionAuthClient {
         .go<void>();
   }
 
+   /**
+   * Sets the tenant id, that will be included in the X-FusionAuth-TenantId header.
+   *
+   * @param {string | null} tenantId The value of the X-FusionAuth-TenantId header.
+   * @returns {Promise<ClientResponse<void>>}
+   */
+  setTenantId(tenantId: string | null) {
+    this.tenantId = tenantId;
+  }
 
   /* ===================================================================================================================
    * Private methods
@@ -2543,7 +2552,7 @@ export class FusionAuthClient {
    * @private
    */
   private start(): IRESTClient {
-    return this.clientBuilder.build(this.host).withAuthorization(this.apiKey);
+    return this.clientBuilder.build(this.host).withAuthorization(this.apiKey).withTenantId(this.tenantId);
   }
 }
 

--- a/src/IRESTClient.ts
+++ b/src/IRESTClient.ts
@@ -17,6 +17,16 @@
 import ClientResponse from "./ClientResponse";
 
 export default interface IRESTClient {
+
+   /**
+   * Sets the authorization header using a key
+   *
+   * @param {string} tenantId The value of the X-FusionAuth-TenantId header.
+   * @returns {DefaultRESTClient}
+   */
+  withTenantId(tenantId): IRESTClient;
+
+
   /**
    * Sets the authorization header using a key
    *


### PR DESCRIPTION
## What is this change?
This PR adds support for the X-FusionAuth-TenantId header. It's now possible to provide a tenantId to the typescript client. The api is the same as that of the nodejs client.

## How is it implemented?
This PR introduces a new class member variable tenantId. If it is defined, the X-FusionAuth-TenantId with it's value gets added to every request. The tenantId can be set using the `setTenantId` method or passed to constructor of the FusionAuthClient.


## Usage
```javascript
const fusionAuthClient = new FusionAuthClient('API_KEY', 'FUSIONATUH_HOST'); 
fusionAuthClient.setTenantId('TENANT_ID');
```
or

```javascript
const fusionAuthClient = new FusionAuthClient('API_KEY', 'FUSIONATUH_HOST', 'TENANT_ID'); 
```