### PR TITLE
Use fetch API instead of request package

### DIFF
--- a/package.json
+++ b/package.json
@@ -51,8 +51,7 @@
     "typescript": "^3.3.1"
   },
   "dependencies": {
-    "request": "^2.88.0",
-    "xhr": "^2.5.0"
+    "cross-fetch": "^3.0.4"
   },
   "browser": {
     "request": "xhr",

--- a/src/FusionAuthClient.ts
+++ b/src/FusionAuthClient.ts
@@ -21,12 +21,13 @@ import ClientResponse from "./ClientResponse";
 
 export class FusionAuthClient {
   public clientBuilder: IRESTClientBuilder = new DefaultRESTClientBuilder();
+  public credentials: RequestCredentials;
 
-  constructor(public apiKey: string, public host: string, public tenantId?: string) {
-    this.apiKey = apiKey;
-    this.host = host;
-    this.tenantId = tenantId;
-  }
+  constructor(
+    public apiKey: string,
+    public host: string,
+    public tenantId?: string,
+  ) { }
 
   /**
    * Sets the tenant id, that will be included in the X-FusionAuth-TenantId header.
@@ -34,8 +35,19 @@ export class FusionAuthClient {
    * @param {string | null} tenantId The value of the X-FusionAuth-TenantId header.
    * @returns {FusionAuthClient}
    */
-  setTenantId(tenantId: string | null) {
+  setTenantId(tenantId: string | null): FusionAuthClient {
     this.tenantId = tenantId;
+    return this;
+  }
+
+  /**
+   * Sets whether and how cookies will be sent with each request.
+   * 
+   * @param value The value that indicates whether and how cookies will be sent.
+   * @returns {FusionAuthClient}
+   */
+  setRequestCredentials(value: RequestCredentials): FusionAuthClient {
+    this.credentials = value;
     return this;
   }
 
@@ -2678,8 +2690,12 @@ export class FusionAuthClient {
   private start(): IRESTClient {
     let client = this.clientBuilder.build(this.host).withAuthorization(this.apiKey);
 
-    if (this.tenantId !== null && typeof(this.tenantId) !== 'undefined') {
+    if (this.tenantId != null) {
       client.withHeader('X-FusionAuth-TenantId', this.tenantId);
+    }
+
+    if (this.credentials != null) {
+      client.withCredentials(this.credentials);
     }
 
     return client;

--- a/src/IRESTClient.ts
+++ b/src/IRESTClient.ts
@@ -23,12 +23,12 @@ export default interface IRESTClient {
    * @param {string} key The value of the authorization header.
    * @returns {IRESTClient}
    */
-  withAuthorization(key): IRESTClient;
+  withAuthorization(key: string): IRESTClient;
 
   /**
    * Adds a segment to the request uri
    */
-  withUriSegment(segment): IRESTClient;
+  withUriSegment(segment: string | number): IRESTClient;
 
   /**
    * Adds a header to the request.
@@ -48,12 +48,12 @@ export default interface IRESTClient {
   /**
    * Sets the http method for the request
    */
-  withMethod(method): IRESTClient;
+  withMethod(method: string): IRESTClient;
 
   /**
    * Sets the uri of the request
    */
-  withUri(uri): IRESTClient;
+  withUri(uri: string): IRESTClient;
 
   /**
    * Adds parameters to the request.
@@ -61,7 +61,14 @@ export default interface IRESTClient {
    * @param name The name of the parameter.
    * @param value The value of the parameter, may be a string, object or number.
    */
-  withParameter(name, value): IRESTClient;
+  withParameter(name: string, value: any): IRESTClient;
+
+  /**
+   * Sets request's credentials.
+   * 
+   * @param value A string indicating whether credentials will be sent with the request always, never, or only when sent to a same-origin URL.
+   */
+  withCredentials(value: RequestCredentials): IRESTClient;
 
   /**
    * Run the request and return a promise. This promise will resolve if the request is successful


### PR DESCRIPTION
I converted the request based code to the fetch API using the `cross-fetch` package for isomorphic behavior. This works both in the browser (tested in Angular) and in NodeJS. One package to rule them all... at least in JS/TS.

I'm also submitting a PR to the `fusionauth-client-build` repository for the actual client changes which have been run against this PR and demonstrate the changes I made to that.