### PR TITLE
[130] Support for the Message Templates API

### DIFF
--- a/build.savant
+++ b/build.savant
@@ -15,7 +15,7 @@
  */
 savantVersion = "1.0.0"
 
-project(group: "io.fusionauth", name: "fusionauth-typescript-client", version: "1.21.1", licenses: ["ApacheV2_0"]) {
+project(group: "io.fusionauth", name: "fusionauth-typescript-client", version: "1.22.0", licenses: ["ApacheV2_0"]) {
   workflow {
     standard()
   }

--- a/build.savant
+++ b/build.savant
@@ -15,7 +15,7 @@
  */
 savantVersion = "1.0.0"
 
-project(group: "io.fusionauth", name: "fusionauth-typescript-client", version: "1.22.0", licenses: ["ApacheV2_0"]) {
+project(group: "io.fusionauth", name: "fusionauth-typescript-client", version: "1.23.0", licenses: ["ApacheV2_0"]) {
   workflow {
     standard()
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@fusionauth/typescript-client",
-  "version": "1.21.1",
+  "version": "1.22.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,6 +1,6 @@
 {
   "name": "@fusionauth/typescript-client",
-  "version": "1.22.0",
+  "version": "1.23.0",
   "lockfileVersion": 1,
   "requires": true,
   "dependencies": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fusionauth/typescript-client",
-  "version": "1.22.0",
+  "version": "1.23.0",
   "description": "A typescript implementation of the FusionAuth client.",
   "main": "build/index.js",
   "types": "build/index.d.ts",

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@fusionauth/typescript-client",
-  "version": "1.21.1",
+  "version": "1.22.0",
   "description": "A typescript implementation of the FusionAuth client.",
   "main": "build/index.js",
   "types": "build/index.d.ts",

--- a/src/FusionAuthClient.ts
+++ b/src/FusionAuthClient.ts
@@ -5493,6 +5493,34 @@ export interface MemberResponse {
   members?: Record<UUID, Array<GroupMember>>;
 }
 
+/**
+ * Stores an message template used to distribute messages;
+ *
+ * @author Michael Sleevi
+ */
+export interface MessageTemplate {
+  defaultTemplate?: string;
+  id?: UUID;
+  insertInstant?: number;
+  lastUpdateInstant?: number;
+  localizedTemplates?: LocalizedStrings;
+  name?: string;
+}
+
+/**
+ * A Message Template Request to the API
+ *
+ * @author Michael Sleevi
+ */
+export interface MessageTemplateRequest {
+  messageTemplate?: MessageTemplate;
+}
+
+export interface MessageTemplateResponse {
+  messageTemplate?: MessageTemplate;
+  messageTemplates?: Array<MessageTemplate>;
+}
+
 export interface MetaData {
   device?: DeviceInfo;
   scopes?: Array<string>;

--- a/src/FusionAuthClient.ts
+++ b/src/FusionAuthClient.ts
@@ -360,6 +360,22 @@ export class FusionAuthClient {
   }
 
   /**
+   * Creates an message template. You can optionally specify an Id for the template, if not provided one will be generated.
+   *
+   * @param {UUID} messageTemplateId (Optional) The Id for the template. If not provided a secure random UUID will be generated.
+   * @param {MessageTemplateRequest} request The request object that contains all of the information used to create the message template.
+   * @returns {Promise<ClientResponse<MessageTemplateResponse>>}
+   */
+  createMessageTemplate(messageTemplateId: UUID, request: MessageTemplateRequest): Promise<ClientResponse<MessageTemplateResponse>> {
+    return this.start<MessageTemplateResponse, Errors>()
+        .withUri('/api/message/template')
+        .withUriSegment(messageTemplateId)
+        .withJSONBody(request)
+        .withMethod("POST")
+        .go();
+  }
+
+  /**
    * Creates a tenant. You can optionally specify an Id for the tenant, if not provided one will be generated.
    *
    * @param {UUID} tenantId (Optional) The Id for the tenant. If not provided a secure random UUID will be generated.
@@ -721,6 +737,20 @@ export class FusionAuthClient {
     return this.start<void, Errors>()
         .withUri('/api/lambda')
         .withUriSegment(lambdaId)
+        .withMethod("DELETE")
+        .go();
+  }
+
+  /**
+   * Deletes the message template for the given Id.
+   *
+   * @param {UUID} messageTemplateId The Id of the message template to delete.
+   * @returns {Promise<ClientResponse<void>>}
+   */
+  deleteMessageTemplate(messageTemplateId: UUID): Promise<ClientResponse<void>> {
+    return this.start<void, Errors>()
+        .withUri('/api/message/template')
+        .withUriSegment(messageTemplateId)
         .withMethod("DELETE")
         .go();
   }
@@ -1477,6 +1507,22 @@ export class FusionAuthClient {
     return this.start<LambdaResponse, Errors>()
         .withUri('/api/lambda')
         .withUriSegment(lambdaId)
+        .withJSONBody(request)
+        .withMethod("PATCH")
+        .go();
+  }
+
+  /**
+   * Updates, via PATCH, the message template with the given Id.
+   *
+   * @param {UUID} messageTemplateId The Id of the message template to update.
+   * @param {MessageTemplateRequest} request The request that contains just the new message template information.
+   * @returns {Promise<ClientResponse<MessageTemplateResponse>>}
+   */
+  patchMessageTemplate(messageTemplateId: UUID, request: MessageTemplateRequest): Promise<ClientResponse<MessageTemplateResponse>> {
+    return this.start<MessageTemplateResponse, Errors>()
+        .withUri('/api/message/template')
+        .withUriSegment(messageTemplateId)
         .withJSONBody(request)
         .withMethod("PATCH")
         .go();
@@ -2311,6 +2357,32 @@ export class FusionAuthClient {
         .withParameter('applicationId', applicationId)
         .withParameter('start', start)
         .withParameter('end', end)
+        .withMethod("GET")
+        .go();
+  }
+
+  /**
+   * Retrieves the message template for the given Id. If you don't specify the id, this will return all of the message templates.
+   *
+   * @param {UUID} messageTemplateId (Optional) The Id of the message template.
+   * @returns {Promise<ClientResponse<MessageTemplateResponse>>}
+   */
+  retrieveMessageTemplate(messageTemplateId: UUID): Promise<ClientResponse<MessageTemplateResponse>> {
+    return this.start<MessageTemplateResponse, void>()
+        .withUri('/api/message/template')
+        .withUriSegment(messageTemplateId)
+        .withMethod("GET")
+        .go();
+  }
+
+  /**
+   * Retrieves all of the message templates.
+   *
+   * @returns {Promise<ClientResponse<MessageTemplateResponse>>}
+   */
+  retrieveMessageTemplates(): Promise<ClientResponse<MessageTemplateResponse>> {
+    return this.start<MessageTemplateResponse, void>()
+        .withUri('/api/message/template')
         .withMethod("GET")
         .go();
   }
@@ -3287,6 +3359,22 @@ export class FusionAuthClient {
     return this.start<LambdaResponse, Errors>()
         .withUri('/api/lambda')
         .withUriSegment(lambdaId)
+        .withJSONBody(request)
+        .withMethod("PUT")
+        .go();
+  }
+
+  /**
+   * Updates the message template with the given Id.
+   *
+   * @param {UUID} messageTemplateId The Id of the message template to update.
+   * @param {MessageTemplateRequest} request The request that contains all of the new message template information.
+   * @returns {Promise<ClientResponse<MessageTemplateResponse>>}
+   */
+  updateMessageTemplate(messageTemplateId: UUID, request: MessageTemplateRequest): Promise<ClientResponse<MessageTemplateResponse>> {
+    return this.start<MessageTemplateResponse, Errors>()
+        .withUri('/api/message/template')
+        .withUriSegment(messageTemplateId)
         .withJSONBody(request)
         .withMethod("PUT")
         .go();
@@ -5237,13 +5325,13 @@ export interface Lambda extends Enableable {
 }
 
 export interface LambdaConfiguration {
-  reconcileId?: UUID;
-}
-
-export interface LambdaConfiguration {
   accessTokenPopulateId?: UUID;
   idTokenPopulateId?: UUID;
   samlv2PopulateId?: UUID;
+}
+
+export interface LambdaConfiguration {
+  reconcileId?: UUID;
 }
 
 export interface LambdaConfiguration {

--- a/src/FusionAuthClient.ts
+++ b/src/FusionAuthClient.ts
@@ -5325,13 +5325,13 @@ export interface Lambda extends Enableable {
 }
 
 export interface LambdaConfiguration {
-  accessTokenPopulateId?: UUID;
-  idTokenPopulateId?: UUID;
-  samlv2PopulateId?: UUID;
+  reconcileId?: UUID;
 }
 
 export interface LambdaConfiguration {
-  reconcileId?: UUID;
+  accessTokenPopulateId?: UUID;
+  idTokenPopulateId?: UUID;
+  samlv2PopulateId?: UUID;
 }
 
 export interface LambdaConfiguration {

--- a/src/FusionAuthClient.ts
+++ b/src/FusionAuthClient.ts
@@ -2376,6 +2376,20 @@ export class FusionAuthClient {
   }
 
   /**
+   * Creates a preview of the message template provided in the request, normalized to a given locale.
+   *
+   * @param {PreviewMessageTemplateRequest} request The request that contains the email template and optionally a locale to render it in.
+   * @returns {Promise<ClientResponse<PreviewMessageTemplateResponse>>}
+   */
+  retrieveMessageTemplatePreview(request: PreviewMessageTemplateRequest): Promise<ClientResponse<PreviewMessageTemplateResponse>> {
+    return this.start<PreviewMessageTemplateResponse, Errors>()
+        .withUri('/api/message/template/preview')
+        .withJSONBody(request)
+        .withMethod("POST")
+        .go();
+  }
+
+  /**
    * Retrieves all of the message templates.
    *
    * @returns {Promise<ClientResponse<MessageTemplateResponse>>}
@@ -5582,6 +5596,15 @@ export interface MemberResponse {
 }
 
 /**
+ * An incredible simplified view of a message
+ *
+ * @author Michael Sleevi
+ */
+export interface Message {
+  text?: string;
+}
+
+/**
  * Stores an message template used to distribute messages;
  *
  * @author Michael Sleevi
@@ -5884,6 +5907,19 @@ export interface PasswordValidationRulesResponse {
  */
 export interface PendingResponse {
   users?: Array<User>;
+}
+
+/**
+ * @author Michael Sleevi
+ */
+export interface PreviewMessageTemplateRequest {
+  locale?: string;
+  messageTemplate?: MessageTemplate;
+}
+
+export interface PreviewMessageTemplateResponse {
+  errors?: Errors;
+  message?: Message;
 }
 
 /**

--- a/src/FusionAuthClient.ts
+++ b/src/FusionAuthClient.ts
@@ -5237,13 +5237,13 @@ export interface Lambda extends Enableable {
 }
 
 export interface LambdaConfiguration {
-  accessTokenPopulateId?: UUID;
-  idTokenPopulateId?: UUID;
-  samlv2PopulateId?: UUID;
+  reconcileId?: UUID;
 }
 
 export interface LambdaConfiguration {
-  reconcileId?: UUID;
+  accessTokenPopulateId?: UUID;
+  idTokenPopulateId?: UUID;
+  samlv2PopulateId?: UUID;
 }
 
 export interface LambdaConfiguration {


### PR DESCRIPTION
Related Issues
----

* [130](https://github.com/FusionAuth/fusionauth-internal-issues/issues/130)

Background
-----

This PR incorporates the client changes for the support of enhanced MFA functionality.

Implementation Details
-----

* Adds new Message Template methods for interacting with the upcoming APIs, namely:
  * Supports PUT /api/message/template/{id}
  * Supports GET /api/message/template/{id}
  * Supports GET /api/message/template
  * Supports POST /api/message/template
  * Supports DELETE /api/message/template
  * Supports PATCH /api/message/template/{id}
  * Supports POST /api/message/template/preview
* Adds new Domain objects and responses for the upcoming APIs, namely:
  * `io.fusionauth.domain.api.MessageTemplateRequest`
  * `io.fusionauth.domain.api.MessageTemplateResponse`
  * `io.fusionauth.domain.api.PreviewMessageTemplateRequest`
  * `io.fusionauth.domain.api.PreviewMessageTemplateResponse`
  * `io.fusionauth.domain.message.MessageTemplate`
  * `io.fusionauth.domain.message.Message`