### PR TITLE
Update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,5 +38,5 @@ Bug reports and pull requests are welcome on GitHub.
 
 ## License
 
-The gem is available as open source under the terms of the [Apache v2.0 License](https://opensource.org/licenses/Apache-2.0).
+This code is available as open source under the terms of the [Apache v2.0 License](https://opensource.org/licenses/Apache-2.0).
 


### PR DESCRIPTION
The license text mentions `gem`; probably copied from a prior version of the Ruby library README? Changed to `This code` to match the current Ruby and Python library READMEs.