### PR TITLE
fix changePassword function to not send apiKey along with changePasswordId

### DIFF
--- a/src/FusionAuthClient.ts
+++ b/src/FusionAuthClient.ts
@@ -124,7 +124,7 @@ export class FusionAuthClient {
    * @returns {Promise<ClientResponse<ChangePasswordResponse>>}
    */
   changePassword(changePasswordId: string, request: ChangePasswordRequest): Promise<ClientResponse<ChangePasswordResponse>> {
-    return this.start<ChangePasswordResponse, Errors>()
+    return this.startAnonymous<ChangePasswordResponse, Errors>()
         .withUri('/api/user/change-password')
         .withUriSegment(changePasswordId)
         .withJSONBody(request)


### PR DESCRIPTION
Currently, the changePassword function (/src/FusionAuthClient.ts) uses the start function, which sends an Authorization header in the request with the api key.
However, according to the fusionauth docs, if a changePasswordId is sent, there is no need to send an api key.

In internal tests, it seems that this function is broken and fusionauth cannot accept an api key along with changePasswordId (fusionauth version 1.20.0).
When using this function, it sends the api key along with the changePasswordId, and the HTTP response status code was 401, which implies invalid Authorization header. When sending the exact same request without the Authorization header, the response status code was 200 and the password was successfully reset.

The fix is to use startAnonymous instead of start, to prevent sending the api key in the Authorization header, and instead only send the changePasswordId.

