### PR TITLE
use named exports

### DIFF
--- a/index.ts
+++ b/index.ts
@@ -21,5 +21,4 @@ export * from './src/FusionAuthClient';
 export * from './src/IRESTClient';
 export * from './src/DefaultRESTClientBuilder';
 export * from './src/ClientResponse';
-export * from './src/IRESTClient';
 export * from './src/IRESTClientBuilder';

--- a/src/ClientResponse.ts
+++ b/src/ClientResponse.ts
@@ -14,7 +14,7 @@
  * language governing permissions and limitations under the License.
  */
 
-export default class ClientResponse<T> {
+export class ClientResponse<T> {
   public statusCode: number;
   public response: T;
   public exception: Error;

--- a/src/DefaultRESTClient.ts
+++ b/src/DefaultRESTClient.ts
@@ -15,7 +15,7 @@
  */
 
 import IRESTClient, {ErrorResponseHandler, ResponseHandler} from "./IRESTClient";
-import ClientResponse from "./ClientResponse";
+import { ClientResponse } from "./ClientResponse";
 import fetch, {BodyInit, RequestCredentials, Response} from 'node-fetch';
 import {URLSearchParams} from "url";
 

--- a/src/DefaultRESTClientBuilder.ts
+++ b/src/DefaultRESTClientBuilder.ts
@@ -16,9 +16,9 @@
 
 import IRESTClient from "./IRESTClient";
 import DefaultRESTClient from "./DefaultRESTClient";
-import IRESTClientBuilder from "./IRESTClientBuilder";
+import { IRESTClientBuilder } from "./IRESTClientBuilder";
 
-export default class DefaultRESTClientBuilder implements IRESTClientBuilder {
+export class DefaultRESTClientBuilder implements IRESTClientBuilder {
   build<RT, ERT>(host: string): IRESTClient<RT, ERT> {
     return new DefaultRESTClient<RT, ERT>(host);
   }

--- a/src/FusionAuthClient.ts
+++ b/src/FusionAuthClient.ts
@@ -15,9 +15,9 @@
 */
 
 import IRESTClient from "./IRESTClient"
-import DefaultRESTClientBuilder from "./DefaultRESTClientBuilder";
-import IRESTClientBuilder from "./IRESTClientBuilder";
-import ClientResponse from "./ClientResponse";
+import { DefaultRESTClientBuilder } from "./DefaultRESTClientBuilder";
+import { IRESTClientBuilder } from "./IRESTClientBuilder";
+import { ClientResponse } from "./ClientResponse";
 import {RequestCredentials} from "node-fetch";
 import {URLSearchParams} from "url";
 

--- a/src/IRESTClient.ts
+++ b/src/IRESTClient.ts
@@ -14,7 +14,7 @@
  * language governing permissions and limitations under the License.
  */
 
-import ClientResponse from "./ClientResponse";
+import { ClientResponse } from "./ClientResponse";
 import {RequestCredentials, Response} from "node-fetch";
 import {URLSearchParams} from "url";
 

--- a/src/IRESTClientBuilder.ts
+++ b/src/IRESTClientBuilder.ts
@@ -15,6 +15,6 @@
  */
 import IRESTClient from "./IRESTClient";
 
-export default interface IRESTClientBuilder {
+export interface IRESTClientBuilder {
   build<RT, ERT>(host: string): IRESTClient<RT, ERT>;
 }


### PR DESCRIPTION
Hi, this PR addresses #27 and removes a duplicated export from `index.ts`.