### PR TITLE
:memo: Adding upgrade policy

### DIFF
--- a/README.md
+++ b/README.md
@@ -40,3 +40,11 @@ Bug reports and pull requests are welcome on GitHub.
 
 This code is available as open source under the terms of the [Apache v2.0 License](https://opensource.org/licenses/Apache-2.0).
 
+
+## Upgrade Policy
+
+This library is built automatically to keep track of the FusionAuth API, and may also receive updates with bug fixes, security patches, tests, code samples, or documentation changes.
+
+These releases may also update dependencies, language engines, and operating systems, as we\'ll follow the deprecation and sunsetting policies of the underlying technologies that it uses.
+
+This means that after a dependency (e.g. language, framework, or operating system) is deprecated by its maintainer, this library will also be deprecated by us, and will eventually be updated to use a newer version.


### PR DESCRIPTION
Adding the "Upgrade Policy" section as [described here](https://github.com/FusionAuth/fusionauth-site/pull/2916).