### PR TITLE
Merge bhalsey/ENG-2184/sorted_domain_order

### DIFF
--- a/src/FusionAuthClient.ts
+++ b/src/FusionAuthClient.ts
@@ -5604,1709 +5604,64 @@ export type UUID = string;
 
 
 /**
- * Identity Provider response.
+ * domain POJO to represent AuthenticationKey
  *
- * @author Spencer Witt
+ * @author sanjay
  */
-export interface IdentityProviderSearchResponse {
-  identityProviders?: Array<BaseIdentityProvider<any>>;
-  total?: number;
-}
-
-/**
- * Authorization Grant types as defined by the <a href="https://tools.ietf.org/html/rfc6749">The OAuth 2.0 Authorization
- * Framework - RFC 6749</a>.
- * <p>
- * Specific names as defined by <a href="https://tools.ietf.org/html/rfc7591#section-4.1">
- * OAuth 2.0 Dynamic Client Registration Protocol - RFC 7591 Section 4.1</a>
- *
- * @author Daniel DeGroff
- */
-export enum GrantType {
-  authorization_code = "authorization_code",
-  implicit = "implicit",
-  password = "password",
-  client_credentials = "client_credentials",
-  refresh_token = "refresh_token",
-  unknown = "unknown",
-  device_code = "urn:ietf:params:oauth:grant-type:device_code"
-}
-
-/**
- * Used to indicate what type of attestation was included in the authenticator response for a given WebAuthn credential at the time it was created
- *
- * @author Spencer Witt
- */
-export enum AttestationType {
-  basic = "basic",
-  self = "self",
-  attestationCa = "attestationCa",
-  anonymizationCa = "anonymizationCa",
-  none = "none"
-}
-
-/**
- * @author Daniel DeGroff
- */
-export interface BaseExportRequest {
-  dateTimeSecondsFormat?: string;
-  zoneId?: string;
-}
-
-/**
- * Models the User Created Registration Event.
- * <p>
- * This is different than the user.registration.create event in that it will be sent after the user has been created. This event cannot be made
- * transactional.
- *
- * @author Daniel DeGroff
- */
-export interface UserRegistrationCreateCompleteEvent extends BaseUserEvent {
-  applicationId?: UUID;
-  registration?: UserRegistration;
-}
-
-/**
- * The user action response object.
- *
- * @author Brian Pontarelli
- */
-export interface ActionResponse {
-  action?: UserActionLog;
-  actions?: Array<UserActionLog>;
-}
-
-/**
- * @author Michael Sleevi
- */
-export interface SMSMessage {
-  phoneNumber?: string;
-  textMessage?: string;
-}
-
-/**
- * @author Daniel DeGroff
- */
-export interface MessengerTransport {
-}
-
-/**
- * User registration information for a single application.
- *
- * @author Brian Pontarelli
- */
-export interface UserRegistration {
-  applicationId?: UUID;
-  authenticationToken?: string;
-  cleanSpeakId?: UUID;
-  data?: Record<string, any>;
+export interface APIKey {
+  expirationInstant?: number;
   id?: UUID;
   insertInstant?: number;
-  lastLoginInstant?: number;
+  ipAccessControlListId?: UUID;
+  key?: string;
+  keyManager?: boolean;
   lastUpdateInstant?: number;
-  preferredLanguages?: Array<string>;
-  roles?: Array<string>;
-  timezone?: string;
-  tokens?: Record<string, string>;
-  username?: string;
-  usernameStatus?: ContentStatus;
-  verified?: boolean;
-  verifiedInstant?: number;
-}
-
-/**
- * Base class for requests that can contain event information. This event information is used when sending Webhooks or emails
- * during the transaction. The caller is responsible for ensuring that the event information is correct.
- *
- * @author Brian Pontarelli
- */
-export interface BaseEventRequest {
-  eventInfo?: EventInfo;
-}
-
-/**
- * A webhook call attempt log.
- *
- * @author Spencer Witt
- */
-export interface WebhookAttemptLog {
-  attemptResult?: WebhookAttemptResult;
-  data?: Record<string, any>;
-  endInstant?: number;
-  id?: UUID;
-  startInstant?: number;
-  webhookCallResponse?: WebhookCallResponse;
-  webhookEventLogId?: UUID;
-  webhookId?: UUID;
-}
-
-/**
- * @author Daniel DeGroff
- */
-export interface JWTVendRequest {
-  claims?: Record<string, any>;
-  keyId?: UUID;
-  timeToLiveInSeconds?: number;
-}
-
-/**
- * Event log used internally by FusionAuth to help developers debug hooks, Webhooks, email templates, etc.
- *
- * @author Brian Pontarelli
- */
-export interface EventLog {
-  id?: number;
-  insertInstant?: number;
-  message?: string;
-  type?: EventLogType;
-}
-
-/**
- * @author Daniel DeGroff
- */
-export interface LookupResponse {
-  identityProvider?: IdentityProviderDetails;
-}
-
-export interface IdentityProviderDetails {
-  applicationIds?: Array<UUID>;
-  id?: UUID;
-  idpEndpoint?: string;
+  metaData?: APIKeyMetaData;
   name?: string;
-  oauth2?: IdentityProviderOauth2Configuration;
-  type?: IdentityProviderType;
-}
-
-/**
- * @author Daniel DeGroff
- */
-export interface IntrospectResponse extends Record<string, any> {
-}
-
-/**
- * Models the Group Member Update Event.
- *
- * @author Daniel DeGroff
- */
-export interface GroupMemberUpdateEvent extends BaseGroupEvent {
-  members?: Array<GroupMember>;
-}
-
-/**
- * Search request for webhooks
- *
- * @author Spencer Witt
- */
-export interface WebhookSearchRequest {
-  search?: WebhookSearchCriteria;
-}
-
-/**
- * Change password response object.
- *
- * @author Daniel DeGroff
- */
-export interface ChangePasswordResponse {
-  oneTimePassword?: string;
-  state?: Record<string, any>;
-}
-
-/**
- * A server where events are sent. This includes user action events and any other events sent by FusionAuth.
- *
- * @author Brian Pontarelli
- */
-export interface Webhook {
-  connectTimeout?: number;
-  data?: Record<string, any>;
-  description?: string;
-  eventsEnabled?: Record<EventType, boolean>;
-  global?: boolean;
-  headers?: HTTPHeaders;
-  httpAuthenticationPassword?: string;
-  httpAuthenticationUsername?: string;
-  id?: UUID;
-  insertInstant?: number;
-  lastUpdateInstant?: number;
-  readTimeout?: number;
-  signatureConfiguration?: WebhookSignatureConfiguration;
-  sslCertificate?: string;
-  sslCertificateKeyId?: UUID;
-  tenantIds?: Array<UUID>;
-  url?: string;
-}
-
-/**
- * Available Integrations
- *
- * @author Daniel DeGroff
- */
-export interface Integrations {
-  cleanspeak?: CleanSpeakConfiguration;
-  kafka?: KafkaConfiguration;
-}
-
-/**
- * Search criteria for the event log.
- *
- * @author Brian Pontarelli
- */
-export interface EventLogSearchCriteria extends BaseSearchCriteria {
-  end?: number;
-  message?: string;
-  start?: number;
-  type?: EventLogType;
-}
-
-/**
- * @author Brian Pontarelli
- */
-export interface EmailConfiguration {
-  additionalHeaders?: Array<EmailHeader>;
-  debug?: boolean;
-  defaultFromEmail?: string;
-  defaultFromName?: string;
-  emailUpdateEmailTemplateId?: UUID;
-  emailVerifiedEmailTemplateId?: UUID;
-  forgotPasswordEmailTemplateId?: UUID;
-  host?: string;
-  implicitEmailVerificationAllowed?: boolean;
-  loginIdInUseOnCreateEmailTemplateId?: UUID;
-  loginIdInUseOnUpdateEmailTemplateId?: UUID;
-  loginNewDeviceEmailTemplateId?: UUID;
-  loginSuspiciousEmailTemplateId?: UUID;
-  password?: string;
-  passwordlessEmailTemplateId?: UUID;
-  passwordResetSuccessEmailTemplateId?: UUID;
-  passwordUpdateEmailTemplateId?: UUID;
-  port?: number;
-  properties?: string;
-  security?: EmailSecurityType;
-  setPasswordEmailTemplateId?: UUID;
-  twoFactorMethodAddEmailTemplateId?: UUID;
-  twoFactorMethodRemoveEmailTemplateId?: UUID;
-  unverified?: EmailUnverifiedOptions;
-  username?: string;
-  verificationEmailTemplateId?: UUID;
-  verificationStrategy?: VerificationStrategy;
-  verifyEmail?: boolean;
-  verifyEmailWhenChanged?: boolean;
-}
-
-export enum EmailSecurityType {
-  NONE = "NONE",
-  SSL = "SSL",
-  TLS = "TLS"
-}
-
-/**
- * @author Brett Pontarelli
- */
-export interface TwitchApplicationConfiguration extends BaseIdentityProviderApplicationConfiguration {
-  buttonText?: string;
-  client_id?: string;
-  client_secret?: string;
-  scope?: string;
-}
-
-/**
- * @author Brett Pontarelli
- */
-export interface XboxApplicationConfiguration extends BaseIdentityProviderApplicationConfiguration {
-  buttonText?: string;
-  client_id?: string;
-  client_secret?: string;
-  scope?: string;
-}
-
-/**
- * Models a generic connector.
- *
- * @author Trevor Smith
- */
-export interface GenericConnectorConfiguration extends BaseConnectorConfiguration {
-  authenticationURL?: string;
-  connectTimeout?: number;
-  headers?: HTTPHeaders;
-  httpAuthenticationPassword?: string;
-  httpAuthenticationUsername?: string;
-  readTimeout?: number;
-  sslCertificateKeyId?: UUID;
-}
-
-/**
- * An Event "event" to indicate an event log was created.
- *
- * @author Daniel DeGroff
- */
-export interface EventLogCreateEvent extends BaseEvent {
-  eventLog?: EventLog;
-}
-
-/**
- * @author Brian Pontarelli
- */
-export interface SystemConfiguration {
-  auditLogConfiguration?: AuditLogConfiguration;
-  corsConfiguration?: CORSConfiguration;
-  data?: Record<string, any>;
-  eventLogConfiguration?: EventLogConfiguration;
-  insertInstant?: number;
-  lastUpdateInstant?: number;
-  loginRecordConfiguration?: LoginRecordConfiguration;
-  reportTimezone?: string;
-  trustedProxyConfiguration?: SystemTrustedProxyConfiguration;
-  uiConfiguration?: UIConfiguration;
-  usageDataConfiguration?: UsageDataConfiguration;
-  webhookEventLogConfiguration?: WebhookEventLogConfiguration;
-}
-
-export interface AuditLogConfiguration {
-  delete?: DeleteConfiguration;
-}
-
-export interface DeleteConfiguration extends Enableable {
-  numberOfDaysToRetain?: number;
-}
-
-export interface EventLogConfiguration {
-  numberToRetain?: number;
-}
-
-export interface LoginRecordConfiguration {
-  delete?: DeleteConfiguration;
-}
-
-export interface UIConfiguration {
-  headerColor?: string;
-  logoURL?: string;
-  menuFontColor?: string;
-}
-
-/**
- * @author Daniel DeGroff
- */
-export interface TenantUsernameConfiguration {
-  unique?: UniqueUsernameConfiguration;
-}
-
-export enum UniqueUsernameStrategy {
-  Always = "Always",
-  OnCollision = "OnCollision"
-}
-
-export interface UniqueUsernameConfiguration extends Enableable {
-  numberOfDigits?: number;
-  separator?: string;
-  strategy?: UniqueUsernameStrategy;
-}
-
-/**
- * Consent search response
- *
- * @author Spencer Witt
- */
-export interface ConsentSearchResponse {
-  consents?: Array<Consent>;
-  total?: number;
-}
-
-/**
- * <ul>
- * <li>Bearer Token type as defined by <a href="https://tools.ietf.org/html/rfc6750">RFC 6750</a>.</li>
- * <li>MAC Token type as referenced by <a href="https://tools.ietf.org/html/rfc6749">RFC 6749</a> and
- * <a href="https://tools.ietf.org/html/draft-ietf-oauth-v2-http-mac-05">
- * Draft RFC on OAuth 2.0 Message Authentication Code (MAC) Tokens</a>
- * </li>
- * </ul>
- *
- * @author Daniel DeGroff
- */
-export enum TokenType {
-  Bearer = "Bearer",
-  MAC = "MAC"
-}
-
-/**
- * A grant for an entity to a user or another entity.
- *
- * @author Brian Pontarelli
- */
-export interface EntityGrant {
-  data?: Record<string, any>;
-  entity?: Entity;
-  id?: UUID;
-  insertInstant?: number;
-  lastUpdateInstant?: number;
-  permissions?: Array<string>;
-  recipientEntityId?: UUID;
-  userId?: UUID;
-}
-
-/**
- * Search criteria for user comments.
- *
- * @author Spencer Witt
- */
-export interface UserCommentSearchCriteria extends BaseSearchCriteria {
-  comment?: string;
-  commenterId?: UUID;
-  tenantId?: UUID;
-  userId?: UUID;
-}
-
-/**
- * @author Derek Klatt
- */
-export interface PasswordValidationRules {
-  breachDetection?: PasswordBreachDetection;
-  maxLength?: number;
-  minLength?: number;
-  rememberPreviousPasswords?: RememberPreviousPasswords;
-  requireMixedCase?: boolean;
-  requireNonAlpha?: boolean;
-  requireNumber?: boolean;
-  validateOnLogin?: boolean;
-}
-
-/**
- * Models the User Email Verify Event.
- *
- * @author Trevor Smith
- */
-export interface UserEmailVerifiedEvent extends BaseUserEvent {
-}
-
-/**
- * API response for User consent.
- *
- * @author Daniel DeGroff
- */
-export interface UserConsentResponse {
-  userConsent?: UserConsent;
-  userConsents?: Array<UserConsent>;
-}
-
-/**
- * @author Brian Pontarelli
- */
-export interface PreviewRequest {
-  emailTemplate?: EmailTemplate;
-  locale?: string;
-}
-
-/**
- * @author Mikey Sleevi
- */
-export interface TenantMultiFactorConfiguration {
-  authenticator?: MultiFactorAuthenticatorMethod;
-  email?: MultiFactorEmailMethod;
-  loginPolicy?: MultiFactorLoginPolicy;
-  sms?: MultiFactorSMSMethod;
-}
-
-export interface MultiFactorAuthenticatorMethod extends Enableable {
-  algorithm?: TOTPAlgorithm;
-  codeLength?: number;
-  timeStep?: number;
-}
-
-export interface MultiFactorEmailMethod extends Enableable {
-  templateId?: UUID;
-}
-
-export interface MultiFactorSMSMethod extends Enableable {
-  messengerId?: UUID;
-  templateId?: UUID;
-}
-
-/**
- * Entity grant API response object.
- *
- * @author Brian Pontarelli
- */
-export interface EntityGrantResponse {
-  grant?: EntityGrant;
-  grants?: Array<EntityGrant>;
-}
-
-/**
- * API request to start a WebAuthn authentication ceremony
- *
- * @author Spencer Witt
- */
-export interface WebAuthnStartRequest {
-  applicationId?: UUID;
-  credentialId?: UUID;
-  loginId?: string;
-  state?: Record<string, any>;
-  userId?: UUID;
-  workflow?: WebAuthnWorkflow;
-}
-
-/**
- * API response for consent.
- *
- * @author Daniel DeGroff
- */
-export interface ConsentResponse {
-  consent?: Consent;
-  consents?: Array<Consent>;
-}
-
-/**
- * A User's membership into a Group
- *
- * @author Daniel DeGroff
- */
-export interface GroupMember {
-  data?: Record<string, any>;
-  groupId?: UUID;
-  id?: UUID;
-  insertInstant?: number;
-  user?: User;
-  userId?: UUID;
-}
-
-/**
- * Models an entity that a user can be granted permissions to. Or an entity that can be granted permissions to another entity.
- *
- * @author Brian Pontarelli
- */
-export interface Entity {
-  clientId?: string;
-  clientSecret?: string;
-  data?: Record<string, any>;
-  id?: UUID;
-  insertInstant?: number;
-  lastUpdateInstant?: number;
-  name?: string;
-  parentId?: UUID;
-  tenantId?: UUID;
-  type?: EntityType;
-}
-
-/**
- * @author Daniel DeGroff
- */
-export interface ReactorResponse {
-  status?: ReactorStatus;
-}
-
-/**
- * Login API request object.
- *
- * @author Seth Musselman
- */
-export interface LoginRequest extends BaseLoginRequest {
-  loginId?: string;
-  oneTimePassword?: string;
-  password?: string;
-  twoFactorTrustId?: string;
-}
-
-/**
- * Models the User Identity Provider Unlink Event.
- *
- * @author Rob Davis
- */
-export interface UserIdentityProviderUnlinkEvent extends BaseUserEvent {
-  identityProviderLink?: IdentityProviderLink;
-}
-
-/**
- * WebAuthn Credential API response
- *
- * @author Spencer Witt
- */
-export interface WebAuthnCredentialResponse {
-  credential?: WebAuthnCredential;
-  credentials?: Array<WebAuthnCredential>;
-}
-
-/**
- * Contains the output for the {@code credProps} extension
- *
- * @author Spencer Witt
- */
-export interface CredentialPropertiesOutput {
-  rk?: boolean;
-}
-
-/**
- * IdP Initiated login configuration
- *
- * @author Daniel DeGroff
- */
-export interface SAMLv2IdPInitiatedLoginConfiguration extends Enableable {
-  nameIdFormat?: string;
-}
-
-/**
- * Entity Type API response object.
- *
- * @author Brian Pontarelli
- */
-export interface EntityTypeResponse {
-  entityType?: EntityType;
-  entityTypes?: Array<EntityType>;
-  permission?: EntityTypePermission;
-}
-
-/**
- * User API response object.
- *
- * @author Brian Pontarelli
- */
-export interface UserResponse {
-  emailVerificationId?: string;
-  emailVerificationOneTimeCode?: string;
-  registrationVerificationIds?: Record<UUID, string>;
-  registrationVerificationOneTimeCodes?: Record<UUID, string>;
-  token?: string;
-  tokenExpirationInstant?: number;
-  user?: User;
-}
-
-/**
- * Status for content like usernames, profile attributes, etc.
- *
- * @author Brian Pontarelli
- */
-export enum ContentStatus {
-  ACTIVE = "ACTIVE",
-  PENDING = "PENDING",
-  REJECTED = "REJECTED"
-}
-
-/**
- * Search request for Keys
- *
- * @author Spencer Witt
- */
-export interface KeySearchRequest {
-  search?: KeySearchCriteria;
-}
-
-/**
- * @author Matthew Altman
- */
-export enum LogoutBehavior {
-  RedirectOnly = "RedirectOnly",
-  AllApplications = "AllApplications"
-}
-
-/**
- * @author Brian Pontarelli
- */
-export interface Tenantable {
-}
-
-/**
- * Models the User Bulk Create Event.
- *
- * @author Brian Pontarelli
- */
-export interface UserBulkCreateEvent extends BaseEvent {
-  users?: Array<User>;
-}
-
-/**
- * Models a single family member.
- *
- * @author Brian Pontarelli
- */
-export interface FamilyMember {
-  data?: Record<string, any>;
-  insertInstant?: number;
-  lastUpdateInstant?: number;
-  owner?: boolean;
-  role?: FamilyRole;
-  userId?: UUID;
-}
-
-export enum FamilyRole {
-  Child = "Child",
-  Teen = "Teen",
-  Adult = "Adult"
-}
-
-/**
- * An email address.
- *
- * @author Brian Pontarelli
- */
-export interface EmailAddress {
-  address?: string;
-  display?: string;
-}
-
-/**
- * @author Daniel DeGroff
- */
-export interface ExternalJWTApplicationConfiguration extends BaseIdentityProviderApplicationConfiguration {
-}
-
-/**
- * Search request for Tenants
- *
- * @author Mark Manes
- */
-export interface TenantSearchRequest {
-  search?: TenantSearchCriteria;
-}
-
-/**
- * @author Daniel DeGroff
- */
-export interface FacebookApplicationConfiguration extends BaseIdentityProviderApplicationConfiguration {
-  appId?: string;
-  buttonText?: string;
-  client_secret?: string;
-  fields?: string;
-  loginMethod?: IdentityProviderLoginMethod;
-  permissions?: string;
-}
-
-/**
- * Models the user action Event.
- *
- * @author Brian Pontarelli
- */
-export interface UserActionEvent extends BaseEvent {
-  action?: string;
-  actioneeUserId?: UUID;
-  actionerUserId?: UUID;
-  actionId?: UUID;
-  applicationIds?: Array<UUID>;
-  comment?: string;
-  email?: Email;
-  emailedUser?: boolean;
-  expiry?: number;
-  localizedAction?: string;
-  localizedDuration?: string;
-  localizedOption?: string;
-  localizedReason?: string;
-  notifyUser?: boolean;
-  option?: string;
-  phase?: UserActionPhase;
-  reason?: string;
-  reasonCode?: string;
-}
-
-/**
- * Models the User Create Registration Event.
- *
- * @author Daniel DeGroff
- */
-export interface UserRegistrationCreateEvent extends BaseUserEvent {
-  applicationId?: UUID;
-  registration?: UserRegistration;
-}
-
-/**
- * A displayable raw login that includes application name and user loginId.
- *
- * @author Brian Pontarelli
- */
-export interface DisplayableRawLogin extends RawLogin {
-  applicationName?: string;
-  location?: Location;
-  loginId?: string;
-}
-
-/**
- * @author Daniel DeGroff
- */
-export interface UserinfoResponse extends Record<string, any> {
-}
-
-/**
- * A number identifying a cryptographic algorithm. Values should be registered with the <a
- * href="https://www.iana.org/assignments/cose/cose.xhtml#algorithms">IANA COSE Algorithms registry</a>
- *
- * @author Spencer Witt
- */
-export enum CoseAlgorithmIdentifier {
-  ES256 = "SHA256withECDSA",
-  ES384 = "SHA384withECDSA",
-  ES512 = "SHA512withECDSA",
-  RS256 = "SHA256withRSA",
-  RS384 = "SHA384withRSA",
-  RS512 = "SHA512withRSA",
-  PS256 = "SHA-256",
-  PS384 = "SHA-384",
-  PS512 = "SHA-512"
-}
-
-/**
- * @author Daniel DeGroff
- */
-export interface TwoFactorSendRequest {
-  applicationId?: UUID;
-  email?: string;
-  method?: string;
-  methodId?: string;
-  mobilePhone?: string;
-  userId?: UUID;
-}
-
-/**
- * @author Brett Pontarelli
- */
-export interface SteamApplicationConfiguration extends BaseIdentityProviderApplicationConfiguration {
-  apiMode?: SteamAPIMode;
-  buttonText?: string;
-  client_id?: string;
-  scope?: string;
-  webAPIKey?: string;
-}
-
-/**
- * Search criteria for Email templates
- *
- * @author Mark Manes
- */
-export interface EmailTemplateSearchCriteria extends BaseSearchCriteria {
-  name?: string;
-}
-
-/**
- * @author Brian Pontarelli
- */
-export enum ReactorFeatureStatus {
-  ACTIVE = "ACTIVE",
-  DISCONNECTED = "DISCONNECTED",
-  PENDING = "PENDING",
-  DISABLED = "DISABLED",
-  UNKNOWN = "UNKNOWN"
-}
-
-/**
- * @author Brett Pontarelli
- */
-export interface SonyPSNApplicationConfiguration extends BaseIdentityProviderApplicationConfiguration {
-  buttonText?: string;
-  client_id?: string;
-  client_secret?: string;
-  scope?: string;
-}
-
-/**
- * An audit log.
- *
- * @author Brian Pontarelli
- */
-export interface AuditLog {
-  data?: Record<string, any>;
-  id?: number;
-  insertInstant?: number;
-  insertUser?: string;
-  message?: string;
-  newValue?: any;
-  oldValue?: any;
-  reason?: string;
-}
-
-/**
- * A webhook call response.
- *
- * @author Spencer Witt
- */
-export interface WebhookCallResponse {
-  exception?: string;
-  statusCode?: number;
-  url?: string;
-}
-
-/**
- * Search request for user comments
- *
- * @author Spencer Witt
- */
-export interface UserCommentSearchRequest {
-  search?: UserCommentSearchCriteria;
-}
-
-/**
- * Provides the <i>authenticator</i> with the data it needs to generate an assertion.
- *
- * @author Spencer Witt
- */
-export interface PublicKeyCredentialRequestOptions {
-  allowCredentials?: Array<PublicKeyCredentialDescriptor>;
-  challenge?: string;
-  rpId?: string;
-  timeout?: number;
-  userVerification?: UserVerificationRequirement;
-}
-
-/**
- * @author Daniel DeGroff
- */
-export enum UnverifiedBehavior {
-  Allow = "Allow",
-  Gated = "Gated"
-}
-
-/**
- * Models the Group Member Remove Event.
- *
- * @author Daniel DeGroff
- */
-export interface GroupMemberRemoveEvent extends BaseGroupEvent {
-  members?: Array<GroupMember>;
-}
-
-/**
- * @author Brett Guy
- */
-export enum MessengerType {
-  Generic = "Generic",
-  Kafka = "Kafka",
-  Twilio = "Twilio"
-}
-
-/**
- * Event log response.
- *
- * @author Brian Pontarelli
- */
-export interface EventLogSearchResponse {
-  eventLogs?: Array<EventLog>;
-  total?: number;
-}
-
-/**
- * @author Brian Pontarelli
- */
-export interface EventLogSearchRequest {
-  search?: EventLogSearchCriteria;
-}
-
-/**
- * Webhook event log response.
- *
- * @author Spencer Witt
- */
-export interface WebhookEventLogResponse {
-  webhookEventLog?: WebhookEventLog;
-}
-
-/**
- * @author Daniel DeGroff
- */
-export interface TwoFactorRecoveryCodeResponse {
-  recoveryCodes?: Array<string>;
-}
-
-/**
- * An expandable API response.
- *
- * @author Daniel DeGroff
- */
-export interface ExpandableResponse {
-  expandable?: Array<string>;
-}
-
-/**
- * Model a user event when a two-factor method has been added.
- *
- * @author Daniel DeGroff
- */
-export interface UserTwoFactorMethodRemoveEvent extends BaseUserEvent {
-  method?: TwoFactorMethod;
-}
-
-/**
- * The response from the total report. This report stores the total numbers for each application.
- *
- * @author Brian Pontarelli
- */
-export interface TotalsReportResponse {
-  applicationTotals?: Record<UUID, Totals>;
-  globalRegistrations?: number;
-  totalGlobalRegistrations?: number;
-}
-
-export interface Totals {
-  logins?: number;
-  registrations?: number;
-  totalRegistrations?: number;
-}
-
-/**
- * @author Brett Guy
- */
-export interface IPAccessControlListResponse {
-  ipAccessControlList?: IPAccessControlList;
-  ipAccessControlLists?: Array<IPAccessControlList>;
-}
-
-/**
- * API request to start a WebAuthn registration ceremony
- *
- * @author Spencer Witt
- */
-export interface WebAuthnRegisterStartRequest {
-  displayName?: string;
-  name?: string;
-  userAgent?: string;
-  userId?: UUID;
-  workflow?: WebAuthnWorkflow;
-}
-
-/**
- * Models the User Login event that is suspicious.
- *
- * @author Daniel DeGroff
- */
-export interface UserLoginSuspiciousEvent extends UserLoginSuccessEvent {
-  threatsDetected?: Array<AuthenticationThreats>;
-}
-
-/**
- * User API delete request object for a single user.
- *
- * @author Brian Pontarelli
- */
-export interface UserDeleteSingleRequest extends BaseEventRequest {
-  hardDelete?: boolean;
-}
-
-/**
- * API response for refreshing a JWT with a Refresh Token.
- * <p>
- * Using a different response object from RefreshTokenResponse because the retrieve response will return an object for refreshToken, and this is a
- * string.
- *
- * @author Daniel DeGroff
- */
-export interface JWTRefreshResponse {
-  refreshToken?: string;
-  refreshTokenId?: UUID;
-  token?: string;
-}
-
-/**
- * @author Brian Pontarelli
- */
-export interface AuditLogSearchRequest {
-  search?: AuditLogSearchCriteria;
-}
-
-/**
- * @author Brett Guy
- */
-export interface IPAccessControlListSearchResponse {
-  ipAccessControlLists?: Array<IPAccessControlList>;
-  total?: number;
-}
-
-/**
- * @author Daniel DeGroff
- */
-export interface VersionResponse {
-  version?: string;
-}
-
-/**
- * @author Brian Pontarelli
- */
-export interface TwoFactorDisableRequest extends BaseEventRequest {
-  applicationId?: UUID;
-  code?: string;
-  methodId?: string;
-}
-
-/**
- * @author Brett Pontarelli
- */
-export interface NintendoApplicationConfiguration extends BaseIdentityProviderApplicationConfiguration {
-  buttonText?: string;
-  client_id?: string;
-  client_secret?: string;
-  emailClaim?: string;
-  scope?: string;
-  uniqueIdClaim?: string;
-  usernameClaim?: string;
-}
-
-/**
- * @author Daniel DeGroff
- */
-export interface PasswordBreachDetection extends Enableable {
-  matchMode?: BreachMatchMode;
-  notifyUserEmailTemplateId?: UUID;
-  onLogin?: BreachAction;
-}
-
-export enum BreachAction {
-  Off = "Off",
-  RecordOnly = "RecordOnly",
-  NotifyUser = "NotifyUser",
-  RequireChange = "RequireChange"
-}
-
-export enum BreachMatchMode {
-  Low = "Low",
-  Medium = "Medium",
-  High = "High"
-}
-
-/**
- * @author Daniel DeGroff
- */
-export enum FormFieldAdminPolicy {
-  Edit = "Edit",
-  View = "View"
-}
-
-/**
- * Used to communicate whether and how authenticator attestation should be delivered to the Relying Party
- *
- * @author Spencer Witt
- */
-export enum AttestationConveyancePreference {
-  none = "none",
-  indirect = "indirect",
-  direct = "direct",
-  enterprise = "enterprise"
-}
-
-/**
- * A policy to configure if and when the user-action is canceled prior to the expiration of the action.
- *
- * @author Daniel DeGroff
- */
-export interface FailedAuthenticationActionCancelPolicy {
-  onPasswordReset?: boolean;
-}
-
-/**
- * The possible result states of a webhook event. This tracks the success of the overall webhook transaction according to the {@link TransactionType}
- * and configured webhooks.
- *
- * @author Spencer Witt
- */
-export enum WebhookEventResult {
-  Failed = "Failed",
-  Running = "Running",
-  Succeeded = "Succeeded"
-}
-
-/**
- * @author Brian Pontarelli
- */
-export interface BaseSearchCriteria {
-  numberOfResults?: number;
-  orderBy?: string;
-  startRow?: number;
-}
-
-/**
- * Forgot password request object.
- *
- * @author Brian Pontarelli
- */
-export interface ForgotPasswordRequest extends BaseEventRequest {
-  applicationId?: UUID;
-  changePasswordId?: string;
-  email?: string;
-  loginId?: string;
-  sendForgotPasswordEmail?: boolean;
-  state?: Record<string, any>;
-  username?: string;
-}
-
-/**
- * The FormField API request object.
- *
- * @author Brett Guy
- */
-export interface FormFieldRequest {
-  field?: FormField;
-  fields?: Array<FormField>;
-}
-
-/**
- * @author Daniel DeGroff
- */
-export interface SendRequest {
-  applicationId?: UUID;
-  bccAddresses?: Array<string>;
-  ccAddresses?: Array<string>;
-  preferredLanguages?: Array<string>;
-  requestData?: Record<string, any>;
-  toAddresses?: Array<EmailAddress>;
-  userIds?: Array<UUID>;
-}
-
-/**
- * @author Michael Sleevi
- */
-export interface MessageTemplateResponse {
-  messageTemplate?: MessageTemplate;
-  messageTemplates?: Array<MessageTemplate>;
-}
-
-/**
- * Identifies the WebAuthn workflow. This will affect the parameters used for credential creation
- * and request based on the Tenant configuration.
- *
- * @author Spencer Witt
- */
-export enum WebAuthnWorkflow {
-  bootstrap = "bootstrap",
-  general = "general",
-  reauthentication = "reauthentication"
-}
-
-/**
- * Models a consent.
- *
- * @author Daniel DeGroff
- */
-export enum ConsentStatus {
-  Active = "Active",
-  Revoked = "Revoked"
-}
-
-/**
- * Models the User Deleted Registration Event.
- * <p>
- * This is different than user.registration.delete in that it is sent after the TX has been committed. This event cannot be transactional.
- *
- * @author Daniel DeGroff
- */
-export interface UserRegistrationDeleteCompleteEvent extends BaseUserEvent {
-  applicationId?: UUID;
-  registration?: UserRegistration;
-}
-
-/**
- * @author Daniel DeGroff
- */
-export enum HTTPMethod {
-  GET = "GET",
-  POST = "POST",
-  PUT = "PUT",
-  DELETE = "DELETE",
-  HEAD = "HEAD",
-  OPTIONS = "OPTIONS",
-  PATCH = "PATCH"
-}
-
-/**
- * Steam gaming login provider.
- *
- * @author Brett Pontarelli
- */
-export interface SteamIdentityProvider extends BaseIdentityProvider<SteamApplicationConfiguration> {
-  apiMode?: SteamAPIMode;
-  buttonText?: string;
-  client_id?: string;
-  scope?: string;
-  webAPIKey?: string;
-}
-
-/**
- * Nintendo gaming login provider.
- *
- * @author Brett Pontarelli
- */
-export interface NintendoIdentityProvider extends BaseIdentityProvider<NintendoApplicationConfiguration> {
-  buttonText?: string;
-  client_id?: string;
-  client_secret?: string;
-  emailClaim?: string;
-  scope?: string;
-  uniqueIdClaim?: string;
-  usernameClaim?: string;
-}
-
-/**
- * @author Daniel DeGroff
- */
-export interface TwoFactorLoginRequest extends BaseLoginRequest {
-  code?: string;
-  trustComputer?: boolean;
-  twoFactorId?: string;
-  userId?: UUID;
-}
-
-/**
- * Search API request.
- *
- * @author Brian Pontarelli
- */
-export interface SearchRequest extends ExpandableRequest {
-  search?: UserSearchCriteria;
-}
-
-/**
- * @author Daniel DeGroff
- */
-export interface BaseIdentityProviderApplicationConfiguration extends Enableable {
-  createRegistration?: boolean;
-  data?: Record<string, any>;
-}
-
-/**
- * This class is an abstraction of a simple email message.
- *
- * @author Brian Pontarelli
- */
-export interface Email {
-  attachments?: Array<Attachment>;
-  bcc?: Array<EmailAddress>;
-  cc?: Array<EmailAddress>;
-  from?: EmailAddress;
-  html?: string;
-  replyTo?: EmailAddress;
-  subject?: string;
-  text?: string;
-  to?: Array<EmailAddress>;
-}
-
-/**
- * Search request for Lambdas
- *
- * @author Mark Manes
- */
-export interface LambdaSearchRequest {
-  search?: LambdaSearchCriteria;
-}
-
-/**
- * Config for Usage Data / Stats
- *
- * @author Lyle Schemmerling
- */
-export interface UsageDataConfiguration extends Enableable {
-  numberOfDaysToRetain?: number;
-}
-
-/**
- * User login failed reason codes.
- */
-export interface UserLoginFailedReasonCode {
-}
-
-/**
- * @author Brian Pontarelli
- */
-export interface BaseElasticSearchCriteria extends BaseSearchCriteria {
-  accurateTotal?: boolean;
-  ids?: Array<UUID>;
-  nextResults?: string;
-  query?: string;
-  queryString?: string;
-  sortFields?: Array<SortField>;
-}
-
-/**
- * Application search response
- *
- * @author Spencer Witt
- */
-export interface ApplicationSearchResponse extends ExpandableResponse {
-  applications?: Array<Application>;
-  total?: number;
-}
-
-/**
- * Lambda search response
- *
- * @author Mark Manes
- */
-export interface LambdaSearchResponse {
-  lambdas?: Array<Lambda>;
-  total?: number;
-}
-
-/**
- * Webhook attempt log response.
- *
- * @author Spencer Witt
- */
-export interface WebhookAttemptLogResponse {
-  webhookAttemptLog?: WebhookAttemptLog;
-}
-
-/**
- * Password Encryption Scheme Configuration
- *
- * @author Daniel DeGroff
- */
-export interface PasswordEncryptionConfiguration {
-  encryptionScheme?: string;
-  encryptionSchemeFactor?: number;
-  modifyEncryptionSchemeOnLogin?: boolean;
-}
-
-/**
- * The Application API response.
- *
- * @author Brian Pontarelli
- */
-export interface ApplicationResponse {
-  application?: Application;
-  applications?: Array<Application>;
-  role?: ApplicationRole;
-}
-
-/**
- * Response for the daily active user report.
- *
- * @author Brian Pontarelli
- */
-export interface MonthlyActiveUserReportResponse {
-  monthlyActiveUsers?: Array<Count>;
-  total?: number;
-}
-
-/**
- * @author Tyler Scott
- */
-export interface Group {
-  data?: Record<string, any>;
-  id?: UUID;
-  insertInstant?: number;
-  lastUpdateInstant?: number;
-  name?: string;
-  roles?: Record<UUID, Array<ApplicationRole>>;
+  permissions?: APIKeyPermissions;
+  retrievable?: boolean;
   tenantId?: UUID;
 }
 
-/**
- * @author Daniel DeGroff
- */
-export interface Form {
-  data?: Record<string, any>;
-  id?: UUID;
-  insertInstant?: number;
-  lastUpdateInstant?: number;
-  name?: string;
-  steps?: Array<FormStep>;
-  type?: FormType;
+export interface APIKeyMetaData {
+  attributes?: Record<string, string>;
+}
+
+export interface APIKeyPermissions {
+  endpoints?: Record<string, Array<string>>;
 }
 
 /**
- * Base class for all {@link User}-related events.
+ * Authentication key request object.
  *
- * @author Spencer Witt
+ * @author Sanjay
  */
-export interface BaseUserEvent extends BaseEvent {
-  user?: User;
+export interface APIKeyRequest {
+  apiKey?: APIKey;
+  sourceKeyId?: UUID;
 }
 
 /**
- * @author Daniel DeGroff
- */
-export enum UserState {
-  Authenticated = "Authenticated",
-  AuthenticatedNotRegistered = "AuthenticatedNotRegistered",
-  AuthenticatedNotVerified = "AuthenticatedNotVerified",
-  AuthenticatedRegistrationNotVerified = "AuthenticatedRegistrationNotVerified"
-}
-
-/**
- * The system configuration for Webhook Event Log data.
+ * Authentication key response object.
  *
- * @author Spencer Witt
+ * @author Sanjay
  */
-export interface WebhookEventLogConfiguration extends Enableable {
-  delete?: DeleteConfiguration;
-}
-
-/**
- * Model a user event when a two-factor method has been removed.
- *
- * @author Daniel DeGroff
- */
-export interface UserTwoFactorMethodAddEvent extends BaseUserEvent {
-  method?: TwoFactorMethod;
+export interface APIKeyResponse {
+  apiKey?: APIKey;
 }
 
 /**
  * @author Daniel DeGroff
  */
-export interface LinkedInApplicationConfiguration extends BaseIdentityProviderApplicationConfiguration {
-  buttonText?: string;
-  client_id?: string;
-  client_secret?: string;
+export interface AccessToken {
+  access_token?: string;
+  expires_in?: number;
+  id_token?: string;
+  refresh_token?: string;
+  refresh_token_id?: UUID;
   scope?: string;
-}
-
-/**
- * @author Lyle Schemmerling
- */
-export interface SAMLv2AssertionConfiguration {
-  destination?: SAMLv2DestinationAssertionConfiguration;
-}
-
-/**
- * Theme API response object.
- *
- * @author Trevor Smith
- */
-export interface ThemeResponse {
-  theme?: Theme;
-  themes?: Array<Theme>;
-}
-
-/**
- * The <i>authenticator's</i> response for the authentication ceremony in its encoded format
- *
- * @author Spencer Witt
- */
-export interface WebAuthnAuthenticatorAuthenticationResponse {
-  authenticatorData?: string;
-  clientDataJSON?: string;
-  signature?: string;
-  userHandle?: string;
-}
-
-/**
- * @author Daniel DeGroff
- */
-export interface SecureGeneratorConfiguration {
-  length?: number;
-  type?: SecureGeneratorType;
-}
-
-/**
- * Webhook API request object.
- *
- * @author Brian Pontarelli
- */
-export interface WebhookRequest {
-  webhook?: Webhook;
-}
-
-/**
- * The Application Scope API request object.
- *
- * @author Spencer Witt
- */
-export interface ApplicationOAuthScopeRequest {
-  scope?: ApplicationOAuthScope;
-}
-
-/**
- * Models the User Created Event.
- * <p>
- * This is different than the user.create event in that it will be sent after the user has been created. This event cannot be made transactional.
- *
- * @author Daniel DeGroff
- */
-export interface UserCreateCompleteEvent extends BaseUserEvent {
-}
-
-/**
- * Models the User Password Reset Start Event.
- *
- * @author Daniel DeGroff
- */
-export interface UserPasswordResetStartEvent extends BaseUserEvent {
-}
-
-/**
- * Webhook event log search response.
- *
- * @author Spencer Witt
- */
-export interface WebhookEventLogSearchResponse {
-  total?: number;
-  webhookEventLogs?: Array<WebhookEventLog>;
-}
-
-/**
- * A JavaScript lambda function that is executed during certain events inside FusionAuth.
- *
- * @author Brian Pontarelli
- */
-export interface Lambda {
-  body?: string;
-  debug?: boolean;
-  engineType?: LambdaEngineType;
-  id?: UUID;
-  insertInstant?: number;
-  lastUpdateInstant?: number;
-  name?: string;
-  type?: LambdaType;
-}
-
-/**
- * @author Daniel DeGroff
- */
-export interface HYPRApplicationConfiguration extends BaseIdentityProviderApplicationConfiguration {
-  relyingPartyApplicationId?: string;
-  relyingPartyURL?: string;
-}
-
-/**
- * @author Daniel DeGroff
- */
-export interface FormFieldValidator extends Enableable {
-  expression?: string;
-}
-
-/**
- * @author Daniel DeGroff
- */
-export interface PasswordValidationRulesResponse {
-  passwordValidationRules?: PasswordValidationRules;
-}
-
-/**
- * @author Brian Pontarelli
- */
-export interface EventConfiguration {
-  events?: Record<EventType, EventConfigurationData>;
-}
-
-export interface EventConfigurationData extends Enableable {
-  transactionType?: TransactionType;
-}
-
-/**
- * Refresh token one-time use configuration. This configuration is utilized when the usage policy is
- * configured for one-time use.
- *
- * @author Daniel DeGroff
- */
-export interface RefreshTokenOneTimeUseConfiguration {
-  gracePeriodInSeconds?: number;
-}
-
-/**
- * Models the User Deactivate Event.
- *
- * @author Brian Pontarelli
- */
-export interface UserDeactivateEvent extends BaseUserEvent {
-}
-
-/**
- * Models the User Update Registration Event.
- *
- * @author Daniel DeGroff
- */
-export interface UserRegistrationUpdateEvent extends BaseUserEvent {
-  applicationId?: UUID;
-  original?: UserRegistration;
-  registration?: UserRegistration;
-}
-
-/**
- * Search request for entities
- *
- * @author Brett Guy
- */
-export interface EntitySearchRequest {
-  search?: EntitySearchCriteria;
+  token_type?: TokenType;
+  userId?: UUID;
 }
 
 /**
@@ -7333,2259 +5688,46 @@ export interface ActionData {
 }
 
 /**
- * The Integration Response
- *
- * @author Daniel DeGroff
- */
-export interface IntegrationResponse {
-  integrations?: Integrations;
-}
-
-/**
- * Models the User Password Update Event.
- *
- * @author Daniel DeGroff
- */
-export interface UserPasswordUpdateEvent extends BaseUserEvent {
-}
-
-/**
- * Models the Group Create Event.
- *
- * @author Daniel DeGroff
- */
-export interface GroupCreateEvent extends BaseGroupEvent {
-}
-
-/**
- * @author Daniel DeGroff
- */
-export interface IdentityProviderResponse {
-  identityProvider?: BaseIdentityProvider<any>;
-  identityProviders?: Array<BaseIdentityProvider<any>>;
-}
-
-/**
- * Something that can be enabled and thus also disabled.
- *
- * @author Daniel DeGroff
- */
-export interface Enableable {
-  enabled?: boolean;
-}
-
-/**
- * Models the Group Member Add Event.
- *
- * @author Daniel DeGroff
- */
-export interface GroupMemberAddEvent extends BaseGroupEvent {
-  members?: Array<GroupMember>;
-}
-
-/**
- * Models the User Password Reset Success Event.
- *
- * @author Daniel DeGroff
- */
-export interface UserPasswordResetSuccessEvent extends BaseUserEvent {
-}
-
-/**
- * @author Daniel DeGroff
- */
-export enum RefreshTokenExpirationPolicy {
-  Fixed = "Fixed",
-  SlidingWindow = "SlidingWindow",
-  SlidingWindowWithMaximumLifetime = "SlidingWindowWithMaximumLifetime"
-}
-
-/**
- * The public Status API response
- *
- * @author Daniel DeGroff
- */
-export interface StatusResponse extends Record<string, any> {
-}
-
-/**
- * @author Brett Guy
- */
-export interface KafkaMessengerConfiguration extends BaseMessengerConfiguration {
-  defaultTopic?: string;
-  producer?: Record<string, string>;
-}
-
-/**
- * Models the User Password Breach Event.
- *
- * @author Matthew Altman
- */
-export interface UserPasswordBreachEvent extends BaseUserEvent {
-}
-
-/**
- * The use type of a key.
- *
- * @author Daniel DeGroff
- */
-export enum KeyUse {
-  SignOnly = "SignOnly",
-  SignAndVerify = "SignAndVerify",
-  VerifyOnly = "VerifyOnly"
-}
-
-/**
- * @author Daniel DeGroff
- */
-export interface ApplicationWebAuthnWorkflowConfiguration extends Enableable {
-}
-
-/**
- * Models an entity type that has a specific set of permissions. These are global objects and can be used across tenants.
+ * The user action response object.
  *
  * @author Brian Pontarelli
  */
-export interface EntityType {
-  data?: Record<string, any>;
-  id?: UUID;
-  insertInstant?: number;
-  jwtConfiguration?: EntityJWTConfiguration;
-  lastUpdateInstant?: number;
-  name?: string;
-  permissions?: Array<EntityTypePermission>;
+export interface ActionResponse {
+  action?: UserActionLog;
+  actions?: Array<UserActionLog>;
 }
 
 /**
- * JWT Configuration for entities.
- */
-export interface EntityJWTConfiguration extends Enableable {
-  accessTokenKeyId?: UUID;
-  timeToLiveInSeconds?: number;
-}
-
-/**
- * Models the Group Member Update Complete Event.
+ * Available JSON Web Algorithms (JWA) as described in RFC 7518 available for this JWT implementation.
  *
  * @author Daniel DeGroff
  */
-export interface GroupMemberUpdateCompleteEvent extends BaseGroupEvent {
-  members?: Array<GroupMember>;
-}
-
-/**
- * Search criteria for Consents
- *
- * @author Spencer Witt
- */
-export interface ConsentSearchCriteria extends BaseSearchCriteria {
-  name?: string;
-}
-
-/**
- * A policy for deleting Users based upon some external criteria.
- *
- * @author Trevor Smith
- */
-export interface TimeBasedDeletePolicy extends Enableable {
-  enabledInstant?: number;
-  numberOfDaysToRetain?: number;
-}
-
-/**
- * Raw login information for each time a user logs into an application.
- *
- * @author Brian Pontarelli
- */
-export interface RawLogin {
-  applicationId?: UUID;
-  instant?: number;
-  ipAddress?: string;
-  userId?: UUID;
+export enum Algorithm {
+  ES256 = "ES256",
+  ES384 = "ES384",
+  ES512 = "ES512",
+  HS256 = "HS256",
+  HS384 = "HS384",
+  HS512 = "HS512",
+  PS256 = "PS256",
+  PS384 = "PS384",
+  PS512 = "PS512",
+  RS256 = "RS256",
+  RS384 = "RS384",
+  RS512 = "RS512",
+  none = "none"
 }
 
 /**
  * @author Daniel DeGroff
  */
-export enum BreachedPasswordStatus {
-  None = "None",
-  ExactMatch = "ExactMatch",
-  SubAddressMatch = "SubAddressMatch",
-  PasswordOnly = "PasswordOnly",
-  CommonPassword = "CommonPassword"
-}
-
-/**
- * Base class for all FusionAuth events.
- *
- * @author Brian Pontarelli
- */
-export interface BaseEvent {
-  createInstant?: number;
-  id?: UUID;
-  info?: EventInfo;
-  tenantId?: UUID;
-  type?: EventType;
-}
-
-/**
- * @author Daniel DeGroff
- */
-export interface SystemTrustedProxyConfiguration {
-  trusted?: Array<string>;
-  trustPolicy?: SystemTrustedProxyConfigurationPolicy;
-}
-
-/**
- * Authentication key response object.
- *
- * @author Sanjay
- */
-export interface APIKeyResponse {
-  apiKey?: APIKey;
-}
-
-/**
- * @author Daniel DeGroff
- */
-export interface LoginRecordExportRequest extends BaseExportRequest {
-  criteria?: LoginRecordSearchCriteria;
-}
-
-/**
- * Search criteria for the webhook event log.
- *
- * @author Spencer Witt
- */
-export interface WebhookEventLogSearchCriteria extends BaseSearchCriteria {
-  end?: number;
-  event?: string;
-  eventResult?: WebhookEventResult;
-  eventType?: EventType;
-  start?: number;
-}
-
-/**
- * Application-level configuration for WebAuthn
- *
- * @author Daniel DeGroff
- */
-export interface ApplicationWebAuthnConfiguration extends Enableable {
-  bootstrapWorkflow?: ApplicationWebAuthnWorkflowConfiguration;
-  reauthenticationWorkflow?: ApplicationWebAuthnWorkflowConfiguration;
-}
-
-/**
- * @author Daniel DeGroff
- */
-export interface VerifyEmailRequest extends BaseEventRequest {
-  oneTimeCode?: string;
-  userId?: UUID;
-  verificationId?: string;
-}
-
-/**
- * @author Daniel DeGroff
- */
-export interface SecureIdentity {
-  breachedPasswordLastCheckedInstant?: number;
-  breachedPasswordStatus?: BreachedPasswordStatus;
-  connectorId?: UUID;
-  encryptionScheme?: string;
-  factor?: number;
-  id?: UUID;
-  lastLoginInstant?: number;
-  password?: string;
-  passwordChangeReason?: ChangePasswordReason;
-  passwordChangeRequired?: boolean;
-  passwordLastUpdateInstant?: number;
-  salt?: string;
-  uniqueUsername?: string;
-  username?: string;
-  usernameStatus?: ContentStatus;
-  verified?: boolean;
-  verifiedInstant?: number;
-}
-
-/**
- * @author Daniel DeGroff
- */
-export enum FormControl {
-  checkbox = "checkbox",
-  number = "number",
-  password = "password",
-  radio = "radio",
-  select = "select",
-  textarea = "textarea",
-  text = "text"
-}
-
-/**
- * A raw login record response
- *
- * @author Daniel DeGroff
- */
-export interface LoginRecordSearchResponse {
-  logins?: Array<DisplayableRawLogin>;
-  total?: number;
-}
-
-/**
- * Response for the registration report.
- *
- * @author Brian Pontarelli
- */
-export interface RegistrationReportResponse {
-  hourlyCounts?: Array<Count>;
-  total?: number;
-}
-
-/**
- * Forgot password response object.
- *
- * @author Daniel DeGroff
- */
-export interface ForgotPasswordResponse {
-  changePasswordId?: string;
-}
-
-/**
- * Models a User consent.
- *
- * @author Daniel DeGroff
- */
-export interface UserConsent {
-  consent?: Consent;
-  consentId?: UUID;
-  data?: Record<string, any>;
-  giverUserId?: UUID;
-  id?: UUID;
-  insertInstant?: number;
-  lastUpdateInstant?: number;
-  status?: ConsentStatus;
-  userId?: UUID;
-  values?: Array<string>;
-}
-
-/**
- * @author Daniel DeGroff
- */
-export interface IdentityProviderStartLoginResponse {
-  code?: string;
-}
-
-/**
- * Twitch gaming login provider.
- *
- * @author Brett Pontarelli
- */
-export interface TwitchIdentityProvider extends BaseIdentityProvider<TwitchApplicationConfiguration> {
+export interface AppleApplicationConfiguration extends BaseIdentityProviderApplicationConfiguration {
+  bundleId?: string;
   buttonText?: string;
-  client_id?: string;
-  client_secret?: string;
+  keyId?: UUID;
   scope?: string;
-}
-
-/**
- * Form response.
- *
- * @author Daniel DeGroff
- */
-export interface FormRequest {
-  form?: Form;
-}
-
-/**
- * Tenant search response
- *
- * @author Mark Manes
- */
-export interface TenantSearchResponse {
-  tenants?: Array<Tenant>;
-  total?: number;
-}
-
-/**
- * Key API request object.
- *
- * @author Daniel DeGroff
- */
-export interface KeyRequest {
-  key?: Key;
-}
-
-/**
- * Models an event where a user is being updated and tries to use an "in-use" login Id (email or username).
- *
- * @author Daniel DeGroff
- */
-export interface UserLoginIdDuplicateOnUpdateEvent extends UserLoginIdDuplicateOnCreateEvent {
-}
-
-/**
- * Location information. Useful for IP addresses and other displayable data objects.
- *
- * @author Brian Pontarelli
- */
-export interface Location {
-  city?: string;
-  country?: string;
-  displayString?: string;
-  latitude?: number;
-  longitude?: number;
-  region?: string;
-  zipcode?: string;
-}
-
-/**
- * @author Brett Guy
- */
-export interface IPAccessControlListRequest {
-  ipAccessControlList?: IPAccessControlList;
-}
-
-/**
- * Controls the policy for whether OAuth workflows will more strictly adhere to the OAuth and OIDC specification
- * or run in backwards compatibility mode.
- *
- * @author David Charles
- */
-export enum OAuthScopeHandlingPolicy {
-  Compatibility = "Compatibility",
-  Strict = "Strict"
-}
-
-/**
- * Import request.
- *
- * @author Brian Pontarelli
- */
-export interface ImportRequest extends BaseEventRequest {
-  encryptionScheme?: string;
-  factor?: number;
-  users?: Array<User>;
-  validateDbConstraints?: boolean;
-}
-
-/**
- * Models an event where a user's email is updated outside of a forgot / change password workflow.
- *
- * @author Daniel DeGroff
- */
-export interface UserEmailUpdateEvent extends BaseUserEvent {
-  previousEmail?: string;
-}
-
-/**
- * @author Lyle Schemmerling
- */
-export interface SAMLv2DestinationAssertionConfiguration {
-  alternates?: Array<string>;
-  policy?: SAMLv2DestinationAssertionPolicy;
-}
-
-/**
- * The possible states of an individual webhook attempt to a single endpoint.
- *
- * @author Spencer Witt
- */
-export enum WebhookAttemptResult {
-  Success = "Success",
-  Failure = "Failure",
-  Unknown = "Unknown"
-}
-
-/**
- * Models the User Login Success Event.
- *
- * @author Daniel DeGroff
- */
-export interface UserLoginSuccessEvent extends BaseUserEvent {
-  applicationId?: UUID;
-  authenticationType?: string;
-  connectorId?: UUID;
-  identityProviderId?: UUID;
-  identityProviderName?: string;
-  ipAddress?: string;
-}
-
-/**
- * Models the User Update Registration Event.
- * <p>
- * This is different than user.registration.update in that it is sent after this event completes, this cannot be transactional.
- *
- * @author Daniel DeGroff
- */
-export interface UserRegistrationUpdateCompleteEvent extends BaseUserEvent {
-  applicationId?: UUID;
-  original?: UserRegistration;
-  registration?: UserRegistration;
-}
-
-/**
- * Group API response object.
- *
- * @author Daniel DeGroff
- */
-export interface GroupResponse {
-  group?: Group;
-  groups?: Array<Group>;
-}
-
-/**
- * @author Daniel DeGroff
- */
-export interface GoogleApplicationConfiguration extends BaseIdentityProviderApplicationConfiguration {
-  buttonText?: string;
-  client_id?: string;
-  client_secret?: string;
-  loginMethod?: IdentityProviderLoginMethod;
-  properties?: GoogleIdentityProviderProperties;
-  scope?: string;
-}
-
-/**
- * Event Log Type
- *
- * @author Daniel DeGroff
- */
-export enum EventLogType {
-  Information = "Information",
-  Debug = "Debug",
-  Error = "Error"
-}
-
-/**
- * The transaction types for Webhooks and other event systems within FusionAuth.
- *
- * @author Brian Pontarelli
- */
-export enum TransactionType {
-  None = "None",
-  Any = "Any",
-  SimpleMajority = "SimpleMajority",
-  SuperMajority = "SuperMajority",
-  AbsoluteMajority = "AbsoluteMajority"
-}
-
-/**
- * @author Daniel DeGroff
- */
-export interface TenantFormConfiguration {
-  adminUserFormId?: UUID;
-}
-
-/**
- * Facebook social login provider.
- *
- * @author Brian Pontarelli
- */
-export interface FacebookIdentityProvider extends BaseIdentityProvider<FacebookApplicationConfiguration> {
-  appId?: string;
-  buttonText?: string;
-  client_secret?: string;
-  fields?: string;
-  loginMethod?: IdentityProviderLoginMethod;
-  permissions?: string;
-}
-
-/**
- * Request for the system configuration API.
- *
- * @author Brian Pontarelli
- */
-export interface SystemConfigurationRequest {
-  systemConfiguration?: SystemConfiguration;
-}
-
-/**
- * Email template search response
- *
- * @author Mark Manes
- */
-export interface EmailTemplateSearchResponse {
-  emailTemplates?: Array<EmailTemplate>;
-  total?: number;
-}
-
-/**
- * @author Daniel DeGroff
- */
-export interface EmailUnverifiedOptions {
-  allowEmailChangeWhenGated?: boolean;
-  behavior?: UnverifiedBehavior;
-}
-
-/**
- * COSE key type
- *
- * @author Spencer Witt
- */
-export enum CoseKeyType {
-  Reserved = "0",
-  OKP = "1",
-  EC2 = "2",
-  RSA = "3",
-  Symmetric = "4"
-}
-
-/**
- * @author Brian Pontarelli
- */
-export interface FamilyConfiguration extends Enableable {
-  allowChildRegistrations?: boolean;
-  confirmChildEmailTemplateId?: UUID;
-  deleteOrphanedAccounts?: boolean;
-  deleteOrphanedAccountsDays?: number;
-  familyRequestEmailTemplateId?: UUID;
-  maximumChildAge?: number;
-  minimumOwnerAge?: number;
-  parentEmailRequired?: boolean;
-  parentRegistrationEmailTemplateId?: UUID;
-}
-
-/**
- * API response for completing WebAuthn credential registration or assertion
- *
- * @author Spencer Witt
- */
-export interface WebAuthnRegisterCompleteResponse {
-  credential?: WebAuthnCredential;
-}
-
-/**
- * @author Daniel DeGroff
- */
-export interface TwoFactorStatusResponse {
-  trusts?: Array<TwoFactorTrust>;
-  twoFactorTrustId?: string;
-}
-
-export interface TwoFactorTrust {
-  applicationId?: UUID;
-  expiration?: number;
-  startInstant?: number;
-}
-
-/**
- * @author Brian Pontarelli
- */
-export interface PendingResponse {
-  users?: Array<User>;
-}
-
-/**
- * Search criteria for Groups
- *
- * @author Daniel DeGroff
- */
-export interface GroupSearchCriteria extends BaseSearchCriteria {
-  name?: string;
-  tenantId?: UUID;
-}
-
-/**
- * Models the User Event (and can be converted to JSON) that is used for all user modifications (create, update,
- * delete).
- * <p>
- * This is different than user.delete because it is sent after the tx is committed, this cannot be transactional.
- *
- * @author Daniel DeGroff
- */
-export interface UserDeleteCompleteEvent extends BaseUserEvent {
-}
-
-/**
- * Request to complete the WebAuthn registration ceremony for a new credential,.
- *
- * @author Spencer Witt
- */
-export interface WebAuthnRegisterCompleteRequest {
-  credential?: WebAuthnPublicKeyRegistrationRequest;
-  origin?: string;
-  rpId?: string;
-  userId?: UUID;
-}
-
-/**
- * @author Daniel DeGroff
- */
-export interface SortField {
-  missing?: string;
-  name?: string;
-  order?: Sort;
-}
-
-/**
- * Search criteria for Lambdas
- *
- * @author Mark Manes
- */
-export interface LambdaSearchCriteria extends BaseSearchCriteria {
-  body?: string;
-  name?: string;
-  type?: LambdaType;
-}
-
-/**
- * User API request object.
- *
- * @author Brian Pontarelli
- */
-export interface UserRequest extends BaseEventRequest {
-  applicationId?: UUID;
-  currentPassword?: string;
-  disableDomainBlock?: boolean;
-  sendSetPasswordEmail?: boolean;
-  skipVerification?: boolean;
-  user?: User;
-}
-
-/**
- * @author Daniel DeGroff
- */
-export interface TenantLoginConfiguration {
-  requireAuthentication?: boolean;
-}
-
-/**
- * @author Trevor Smith
- */
-export interface DeviceResponse {
-  device_code?: string;
-  expires_in?: number;
-  interval?: number;
-  user_code?: string;
-  verification_uri?: string;
-  verification_uri_complete?: string;
-}
-
-/**
- * Request for the Logout API that can be used as an alternative to URL parameters.
- *
- * @author Brian Pontarelli
- */
-export interface LogoutRequest extends BaseEventRequest {
-  global?: boolean;
-  refreshToken?: string;
-}
-
-/**
- * @author Daniel DeGroff
- */
-export interface VerifyRegistrationRequest extends BaseEventRequest {
-  oneTimeCode?: string;
-  verificationId?: string;
-}
-
-export enum ThemeType {
-  advanced = "advanced",
-  simple = "simple"
-}
-
-/**
- * @author Daniel DeGroff
- */
-export interface TenantRateLimitConfiguration {
-  failedLogin?: RateLimitedRequestConfiguration;
-  forgotPassword?: RateLimitedRequestConfiguration;
-  sendEmailVerification?: RateLimitedRequestConfiguration;
-  sendPasswordless?: RateLimitedRequestConfiguration;
-  sendRegistrationVerification?: RateLimitedRequestConfiguration;
-  sendTwoFactor?: RateLimitedRequestConfiguration;
-}
-
-/**
- * @author Daniel DeGroff
- */
-export interface Tenant {
-  accessControlConfiguration?: TenantAccessControlConfiguration;
-  captchaConfiguration?: TenantCaptchaConfiguration;
-  configured?: boolean;
-  connectorPolicies?: Array<ConnectorPolicy>;
-  data?: Record<string, any>;
-  emailConfiguration?: EmailConfiguration;
-  eventConfiguration?: EventConfiguration;
-  externalIdentifierConfiguration?: ExternalIdentifierConfiguration;
-  failedAuthenticationConfiguration?: FailedAuthenticationConfiguration;
-  familyConfiguration?: FamilyConfiguration;
-  formConfiguration?: TenantFormConfiguration;
-  httpSessionMaxInactiveInterval?: number;
-  id?: UUID;
-  insertInstant?: number;
-  issuer?: string;
-  jwtConfiguration?: JWTConfiguration;
-  lambdaConfiguration?: TenantLambdaConfiguration;
-  lastUpdateInstant?: number;
-  loginConfiguration?: TenantLoginConfiguration;
-  logoutURL?: string;
-  maximumPasswordAge?: MaximumPasswordAge;
-  minimumPasswordAge?: MinimumPasswordAge;
-  multiFactorConfiguration?: TenantMultiFactorConfiguration;
-  name?: string;
-  oauthConfiguration?: TenantOAuth2Configuration;
-  passwordEncryptionConfiguration?: PasswordEncryptionConfiguration;
-  passwordValidationRules?: PasswordValidationRules;
-  rateLimitConfiguration?: TenantRateLimitConfiguration;
-  registrationConfiguration?: TenantRegistrationConfiguration;
-  scimServerConfiguration?: TenantSCIMServerConfiguration;
-  ssoConfiguration?: TenantSSOConfiguration;
-  state?: ObjectState;
-  themeId?: UUID;
-  userDeletePolicy?: TenantUserDeletePolicy;
-  usernameConfiguration?: TenantUsernameConfiguration;
-  webAuthnConfiguration?: TenantWebAuthnConfiguration;
-}
-
-export interface TenantOAuth2Configuration {
-  clientCredentialsAccessTokenPopulateLambdaId?: UUID;
-}
-
-/**
- * Models the Group Member Add Complete Event.
- *
- * @author Daniel DeGroff
- */
-export interface GroupMemberAddCompleteEvent extends BaseGroupEvent {
-  members?: Array<GroupMember>;
-}
-
-/**
- * Request for the Tenant API to delete a tenant rather than using the URL parameters.
- *
- * @author Brian Pontarelli
- */
-export interface TenantDeleteRequest extends BaseEventRequest {
-  async?: boolean;
-}
-
-/**
- * The types of connectors. This enum is stored as an ordinal on the <code>identities</code> table, order must be maintained.
- *
- * @author Trevor Smith
- */
-export enum ConnectorType {
-  FusionAuth = "FusionAuth",
-  Generic = "Generic",
-  LDAP = "LDAP"
-}
-
-/**
- * Models the User Login event for a new device (un-recognized)
- *
- * @author Daniel DeGroff
- */
-export interface UserLoginNewDeviceEvent extends UserLoginSuccessEvent {
-}
-
-/**
- * @author Spencer Witt
- */
-export interface TenantWebAuthnWorkflowConfiguration extends Enableable {
-  authenticatorAttachmentPreference?: AuthenticatorAttachmentPreference;
-  userVerificationRequirement?: UserVerificationRequirement;
-}
-
-/**
- * Xbox gaming login provider.
- *
- * @author Brett Pontarelli
- */
-export interface XboxIdentityProvider extends BaseIdentityProvider<XboxApplicationConfiguration> {
-  buttonText?: string;
-  client_id?: string;
-  client_secret?: string;
-  scope?: string;
-}
-
-/**
- * @author Daniel DeGroff
- */
-export interface TwitterApplicationConfiguration extends BaseIdentityProviderApplicationConfiguration {
-  buttonText?: string;
-  consumerKey?: string;
-  consumerSecret?: string;
-}
-
-/**
- * @author Trevor Smith
- */
-export interface ConnectorRequest {
-  connector?: BaseConnectorConfiguration;
-}
-
-/**
- * Request to register a new public key with WebAuthn
- *
- * @author Spencer Witt
- */
-export interface WebAuthnPublicKeyRegistrationRequest {
-  clientExtensionResults?: WebAuthnExtensionsClientOutputs;
-  id?: string;
-  response?: WebAuthnAuthenticatorRegistrationResponse;
-  rpId?: string;
-  transports?: Array<string>;
-  type?: string;
-}
-
-/**
- * External JWT-only identity provider.
- *
- * @author Daniel DeGroff and Brian Pontarelli
- */
-export interface ExternalJWTIdentityProvider extends BaseIdentityProvider<ExternalJWTApplicationConfiguration> {
-  claimMap?: Record<string, string>;
-  defaultKeyId?: UUID;
-  domains?: Array<string>;
-  headerKeyParameter?: string;
-  oauth2?: IdentityProviderOauth2Configuration;
-  uniqueIdentityClaim?: string;
-}
-
-/**
- * Webhook search response
- *
- * @author Spencer Witt
- */
-export interface WebhookSearchResponse {
-  total?: number;
-  webhooks?: Array<Webhook>;
-}
-
-/**
- * @author Daniel DeGroff
- */
-export interface RefreshResponse {
-}
-
-/**
- * Response for the login report.
- *
- * @author Brian Pontarelli
- */
-export interface LoginReportResponse {
-  hourlyCounts?: Array<Count>;
-  total?: number;
-}
-
-/**
- * Group Member Delete Request
- *
- * @author Daniel DeGroff
- */
-export interface MemberDeleteRequest {
-  memberIds?: Array<UUID>;
-  members?: Record<UUID, Array<UUID>>;
-}
-
-/**
- * A historical state of a user log event. Since events can be modified, this stores the historical state.
- *
- * @author Brian Pontarelli
- */
-export interface LogHistory {
-  historyItems?: Array<HistoryItem>;
-}
-
-export interface HistoryItem {
-  actionerUserId?: UUID;
-  comment?: string;
-  createInstant?: number;
-  expiry?: number;
-}
-
-/**
- * @author Brian Pontarelli
- */
-export interface AuditLogRequest extends BaseEventRequest {
-  auditLog?: AuditLog;
-}
-
-/**
- * @author Daniel DeGroff
- */
-export interface RateLimitedRequestConfiguration extends Enableable {
-  limit?: number;
-  timePeriodInSeconds?: number;
-}
-
-/**
- * A marker interface indicating this event cannot be made transactional.
- *
- * @author Daniel DeGroff
- */
-export interface NonTransactionalEvent {
-}
-
-/**
- * @author Daniel DeGroff
- */
-export interface TwoFactorResponse {
-  code?: string;
-  recoveryCodes?: Array<string>;
-}
-
-/**
- * @author Brett Guy
- */
-export enum ProofKeyForCodeExchangePolicy {
-  Required = "Required",
-  NotRequired = "NotRequired",
-  NotRequiredWhenUsingClientAuthentication = "NotRequiredWhenUsingClientAuthentication"
-}
-
-/**
- * Epic gaming login provider.
- *
- * @author Brett Pontarelli
- */
-export interface EpicGamesIdentityProvider extends BaseIdentityProvider<EpicGamesApplicationConfiguration> {
-  buttonText?: string;
-  client_id?: string;
-  client_secret?: string;
-  scope?: string;
-}
-
-// Do not require a setter for 'type', it is defined by the concrete class and is not mutable
-export interface BaseMessengerConfiguration {
-  data?: Record<string, any>;
-  debug?: boolean;
-  id?: UUID;
-  insertInstant?: number;
-  lastUpdateInstant?: number;
-  name?: string;
-  transport?: string;
-  type?: MessengerType;
-}
-
-/**
- * @author Daniel DeGroff
- */
-export interface SecretResponse {
-  secret?: string;
-  secretBase32Encoded?: string;
-}
-
-/**
- * Search request for entities
- *
- * @author Brett Guy
- */
-export interface EntitySearchResponse {
-  entities?: Array<Entity>;
-  nextResults?: string;
-  total?: number;
-}
-
-/**
- * @author Rob Davis
- */
-export interface TenantLambdaConfiguration {
-  loginValidationId?: UUID;
-  scimEnterpriseUserRequestConverterId?: UUID;
-  scimEnterpriseUserResponseConverterId?: UUID;
-  scimGroupRequestConverterId?: UUID;
-  scimGroupResponseConverterId?: UUID;
-  scimUserRequestConverterId?: UUID;
-  scimUserResponseConverterId?: UUID;
-}
-
-/**
- * @author Mikey Sleevi
- */
-export enum MessageType {
-  SMS = "SMS"
-}
-
-/**
- * Describes the Relying Party's requirements for <a href="https://www.w3.org/TR/webauthn-2/#client-side-discoverable-credential">client-side
- * discoverable credentials</a> (formerly known as "resident keys")
- *
- * @author Spencer Witt
- */
-export enum ResidentKeyRequirement {
-  discouraged = "discouraged",
-  preferred = "preferred",
-  required = "required"
-}
-
-/**
- * @author Trevor Smith
- */
-export enum ChangePasswordReason {
-  Administrative = "Administrative",
-  Breached = "Breached",
-  Expired = "Expired",
-  Validation = "Validation"
-}
-
-/**
- * @author Brett Guy
- */
-export interface GenericMessengerConfiguration extends BaseMessengerConfiguration {
-  connectTimeout?: number;
-  headers?: HTTPHeaders;
-  httpAuthenticationPassword?: string;
-  httpAuthenticationUsername?: string;
-  readTimeout?: number;
-  sslCertificate?: string;
-  url?: string;
-}
-
-/**
- * SonyPSN gaming login provider.
- *
- * @author Brett Pontarelli
- */
-export interface SonyPSNIdentityProvider extends BaseIdentityProvider<SonyPSNApplicationConfiguration> {
-  buttonText?: string;
-  client_id?: string;
-  client_secret?: string;
-  scope?: string;
-}
-
-/**
- * @author Brett Guy
- */
-export interface IPAccessControlEntry {
-  action?: IPAccessControlEntryAction;
-  endIPAddress?: string;
-  startIPAddress?: string;
-}
-
-/**
- * @author Brian Pontarelli
- */
-export interface Count {
-  count?: number;
-  interval?: number;
-}
-
-/**
- * Models an LDAP connector.
- *
- * @author Trevor Smith
- */
-export interface LDAPConnectorConfiguration extends BaseConnectorConfiguration {
-  authenticationURL?: string;
-  baseStructure?: string;
-  connectTimeout?: number;
-  identifyingAttribute?: string;
-  lambdaConfiguration?: LambdaConfiguration;
-  loginIdAttribute?: string;
-  readTimeout?: number;
-  requestedAttributes?: Array<string>;
-  securityMethod?: LDAPSecurityMethod;
-  systemAccountDN?: string;
-  systemAccountPassword?: string;
-}
-
-export enum LDAPSecurityMethod {
-  None = "None",
-  LDAPS = "LDAPS",
-  StartTLS = "StartTLS"
-}
-
-export interface LambdaConfiguration {
-  reconcileId?: UUID;
-}
-
-/**
- * @author Johnathon Wood
- */
-export enum Oauth2AuthorizedURLValidationPolicy {
-  AllowWildcards = "AllowWildcards",
-  ExactMatch = "ExactMatch"
-}
-
-/**
- * @author Trevor Smith
- */
-export interface CORSConfiguration extends Enableable {
-  allowCredentials?: boolean;
-  allowedHeaders?: Array<string>;
-  allowedMethods?: Array<HTTPMethod>;
-  allowedOrigins?: Array<string>;
-  debug?: boolean;
-  exposedHeaders?: Array<string>;
-  preflightMaxAgeInSeconds?: number;
-}
-
-/**
- * Describes the <a href="https://www.w3.org/TR/webauthn-2/#authenticator-attachment-modality">authenticator attachment modality</a>.
- *
- * @author Spencer Witt
- */
-export enum AuthenticatorAttachment {
-  platform = "platform",
-  crossPlatform = "crossPlatform"
-}
-
-/**
- * @author Daniel DeGroff
- */
-export interface AuditLogExportRequest extends BaseExportRequest {
-  criteria?: AuditLogSearchCriteria;
-}
-
-/**
- * Supply additional information about the user account when creating a new credential
- *
- * @author Spencer Witt
- */
-export interface PublicKeyCredentialUserEntity extends PublicKeyCredentialEntity {
-  displayName?: string;
-  id?: string;
-}
-
-/**
- * @author Daniel DeGroff
- */
-export interface FormStep {
-  fields?: Array<UUID>;
-}
-
-/**
- * Search criteria for entity types.
- *
- * @author Brian Pontarelli
- */
-export interface EntityTypeSearchCriteria extends BaseSearchCriteria {
-  name?: string;
-}
-
-/**
- * Information about a user event (login, register, etc) that helps identify the source of the event (location, device type, OS, etc).
- *
- * @author Brian Pontarelli
- */
-export interface EventInfo {
-  data?: Record<string, any>;
-  deviceDescription?: string;
-  deviceName?: string;
-  deviceType?: string;
-  ipAddress?: string;
-  location?: Location;
-  os?: string;
-  userAgent?: string;
-}
-
-/**
- * Search criteria for Group Members
- *
- * @author Daniel DeGroff
- */
-export interface GroupMemberSearchCriteria extends BaseSearchCriteria {
-  groupId?: UUID;
-  tenantId?: UUID;
-  userId?: UUID;
-}
-
-/**
- * @author Brett Pontarelli
- */
-export enum IdentityProviderLoginMethod {
-  UsePopup = "UsePopup",
-  UseRedirect = "UseRedirect",
-  UseVendorJavaScript = "UseVendorJavaScript"
-}
-
-/**
- * Search criteria for themes
- *
- * @author Mark Manes
- */
-export interface ThemeSearchCriteria extends BaseSearchCriteria {
-  name?: string;
-  type?: ThemeType;
-}
-
-/**
- * @author Daniel DeGroff
- */
-export interface MinimumPasswordAge extends Enableable {
-  seconds?: number;
-}
-
-/**
- * Login Ping API request object.
- *
- * @author Daniel DeGroff
- */
-export interface LoginPingRequest extends BaseLoginRequest {
-  userId?: UUID;
-}
-
-/**
- * @author Daniel DeGroff
- */
-export interface OpenIdConnectApplicationConfiguration extends BaseIdentityProviderApplicationConfiguration {
-  buttonImageURL?: string;
-  buttonText?: string;
-  oauth2?: IdentityProviderOauth2Configuration;
-}
-
-/**
- * @author Daniel DeGroff
- */
-export interface IdentityProviderTenantConfiguration {
-  data?: Record<string, any>;
-  limitUserLinkCount?: IdentityProviderLimitUserLinkingPolicy;
-}
-
-/**
- * API request for User consent types.
- *
- * @author Daniel DeGroff
- */
-export interface ConsentRequest {
-  consent?: Consent;
-}
-
-/**
- * Supply information on credential type and algorithm to the <i>authenticator</i>.
- *
- * @author Spencer Witt
- */
-export interface PublicKeyCredentialParameters {
-  alg?: CoseAlgorithmIdentifier;
-  type?: PublicKeyCredentialType;
-}
-
-/**
- * Models a set of localized Strings that can be stored as JSON.
- *
- * @author Brian Pontarelli
- */
-export interface LocalizedStrings extends Record<string, string> {
-}
-
-/**
- * @author Daniel DeGroff
- */
-export enum RefreshTokenUsagePolicy {
-  Reusable = "Reusable",
-  OneTimeUse = "OneTimeUse"
-}
-
-/**
- * @author Lyle Schemmerling
- */
-export enum SAMLv2DestinationAssertionPolicy {
-  Enabled = "Enabled",
-  Disabled = "Disabled",
-  AllowAlternates = "AllowAlternates"
-}
-
-/**
- * Interface describing the need for CORS configuration.
- *
- * @author Daniel DeGroff
- */
-export interface RequiresCORSConfiguration {
-}
-
-/**
- * Change password request object.
- *
- * @author Brian Pontarelli
- */
-export interface ChangePasswordRequest extends BaseEventRequest {
-  applicationId?: UUID;
-  changePasswordId?: string;
-  currentPassword?: string;
-  loginId?: string;
-  password?: string;
-  refreshToken?: string;
-  trustChallenge?: string;
-  trustToken?: string;
-}
-
-/**
- * @author Daniel DeGroff
- */
-export interface IdentityProviderStartLoginRequest extends BaseLoginRequest {
-  data?: Record<string, string>;
-  identityProviderId?: UUID;
-  loginId?: string;
-  state?: Record<string, any>;
-}
-
-/**
- * @author Daniel DeGroff
- */
-export interface OAuthError {
-  change_password_id?: string;
-  error?: OAuthErrorType;
-  error_description?: string;
-  error_reason?: OAuthErrorReason;
-  error_uri?: string;
-  two_factor_id?: string;
-  two_factor_methods?: Array<TwoFactorMethod>;
-}
-
-export enum OAuthErrorReason {
-  auth_code_not_found = "auth_code_not_found",
-  access_token_malformed = "access_token_malformed",
-  access_token_expired = "access_token_expired",
-  access_token_unavailable_for_processing = "access_token_unavailable_for_processing",
-  access_token_failed_processing = "access_token_failed_processing",
-  access_token_invalid = "access_token_invalid",
-  access_token_required = "access_token_required",
-  refresh_token_not_found = "refresh_token_not_found",
-  refresh_token_type_not_supported = "refresh_token_type_not_supported",
-  invalid_client_id = "invalid_client_id",
-  invalid_user_credentials = "invalid_user_credentials",
-  invalid_grant_type = "invalid_grant_type",
-  invalid_origin = "invalid_origin",
-  invalid_origin_opaque = "invalid_origin_opaque",
-  invalid_pkce_code_verifier = "invalid_pkce_code_verifier",
-  invalid_pkce_code_challenge = "invalid_pkce_code_challenge",
-  invalid_pkce_code_challenge_method = "invalid_pkce_code_challenge_method",
-  invalid_redirect_uri = "invalid_redirect_uri",
-  invalid_response_mode = "invalid_response_mode",
-  invalid_response_type = "invalid_response_type",
-  invalid_id_token_hint = "invalid_id_token_hint",
-  invalid_post_logout_redirect_uri = "invalid_post_logout_redirect_uri",
-  invalid_device_code = "invalid_device_code",
-  invalid_user_code = "invalid_user_code",
-  invalid_additional_client_id = "invalid_additional_client_id",
-  invalid_target_entity_scope = "invalid_target_entity_scope",
-  invalid_entity_permission_scope = "invalid_entity_permission_scope",
-  invalid_user_id = "invalid_user_id",
-  grant_type_disabled = "grant_type_disabled",
-  missing_client_id = "missing_client_id",
-  missing_client_secret = "missing_client_secret",
-  missing_code = "missing_code",
-  missing_code_challenge = "missing_code_challenge",
-  missing_code_verifier = "missing_code_verifier",
-  missing_device_code = "missing_device_code",
-  missing_grant_type = "missing_grant_type",
-  missing_redirect_uri = "missing_redirect_uri",
-  missing_refresh_token = "missing_refresh_token",
-  missing_response_type = "missing_response_type",
-  missing_token = "missing_token",
-  missing_user_code = "missing_user_code",
-  missing_user_id = "missing_user_id",
-  missing_verification_uri = "missing_verification_uri",
-  login_prevented = "login_prevented",
-  not_licensed = "not_licensed",
-  user_code_expired = "user_code_expired",
-  user_expired = "user_expired",
-  user_locked = "user_locked",
-  user_not_found = "user_not_found",
-  client_authentication_missing = "client_authentication_missing",
-  invalid_client_authentication_scheme = "invalid_client_authentication_scheme",
-  invalid_client_authentication = "invalid_client_authentication",
-  client_id_mismatch = "client_id_mismatch",
-  change_password_administrative = "change_password_administrative",
-  change_password_breached = "change_password_breached",
-  change_password_expired = "change_password_expired",
-  change_password_validation = "change_password_validation",
-  unknown = "unknown",
-  missing_required_scope = "missing_required_scope",
-  unknown_scope = "unknown_scope",
-  consent_canceled = "consent_canceled"
-}
-
-export enum OAuthErrorType {
-  invalid_request = "invalid_request",
-  invalid_client = "invalid_client",
-  invalid_grant = "invalid_grant",
-  invalid_token = "invalid_token",
-  unauthorized_client = "unauthorized_client",
-  invalid_scope = "invalid_scope",
-  server_error = "server_error",
-  unsupported_grant_type = "unsupported_grant_type",
-  unsupported_response_type = "unsupported_response_type",
-  access_denied = "access_denied",
-  change_password_required = "change_password_required",
-  not_licensed = "not_licensed",
-  two_factor_required = "two_factor_required",
-  authorization_pending = "authorization_pending",
-  expired_token = "expired_token",
-  unsupported_token_type = "unsupported_token_type"
-}
-
-/**
- * Interface for all identity providers that can be domain based.
- */
-export interface DomainBasedIdentityProvider {
-}
-
-/**
- * @author Daniel DeGroff
- */
-export interface DeviceInfo {
-  description?: string;
-  lastAccessedAddress?: string;
-  lastAccessedInstant?: number;
-  name?: string;
-  type?: string;
-}
-
-export enum DeviceType {
-  BROWSER = "BROWSER",
-  DESKTOP = "DESKTOP",
-  LAPTOP = "LAPTOP",
-  MOBILE = "MOBILE",
-  OTHER = "OTHER",
-  SERVER = "SERVER",
-  TABLET = "TABLET",
-  TV = "TV",
-  UNKNOWN = "UNKNOWN"
-}
-
-/**
- * Response for the system configuration API.
- *
- * @author Brian Pontarelli
- */
-export interface SystemConfigurationResponse {
-  systemConfiguration?: SystemConfiguration;
-}
-
-/**
- * API response for completing WebAuthn assertion
- *
- * @author Spencer Witt
- */
-export interface WebAuthnAssertResponse {
-  credential?: WebAuthnCredential;
-}
-
-/**
- * @author Daniel DeGroff
- */
-export interface ReactorStatus {
-  advancedIdentityProviders?: ReactorFeatureStatus;
-  advancedLambdas?: ReactorFeatureStatus;
-  advancedMultiFactorAuthentication?: ReactorFeatureStatus;
-  advancedOAuthScopes?: ReactorFeatureStatus;
-  advancedOAuthScopesCustomScopes?: ReactorFeatureStatus;
-  advancedOAuthScopesThirdPartyApplications?: ReactorFeatureStatus;
-  advancedRegistration?: ReactorFeatureStatus;
-  applicationMultiFactorAuthentication?: ReactorFeatureStatus;
-  applicationThemes?: ReactorFeatureStatus;
-  breachedPasswordDetection?: ReactorFeatureStatus;
-  connectors?: ReactorFeatureStatus;
-  entityManagement?: ReactorFeatureStatus;
-  expiration?: string;
-  licenseAttributes?: Record<string, string>;
-  licensed?: boolean;
-  scimServer?: ReactorFeatureStatus;
-  threatDetection?: ReactorFeatureStatus;
-  webAuthn?: ReactorFeatureStatus;
-  webAuthnPlatformAuthenticators?: ReactorFeatureStatus;
-  webAuthnRoamingAuthenticators?: ReactorFeatureStatus;
-}
-
-/**
- * @author Daniel DeGroff
- */
-export enum ApplicationMultiFactorTrustPolicy {
-  Any = "Any",
-  This = "This",
-  None = "None"
-}
-
-/**
- * @author Daniel DeGroff
- */
-export interface MaximumPasswordAge extends Enableable {
-  days?: number;
-}
-
-/**
- * @author Daniel DeGroff
- */
-export enum RateLimitedRequestType {
-  FailedLogin = "FailedLogin",
-  ForgotPassword = "ForgotPassword",
-  SendEmailVerification = "SendEmailVerification",
-  SendPasswordless = "SendPasswordless",
-  SendRegistrationVerification = "SendRegistrationVerification",
-  SendTwoFactor = "SendTwoFactor"
-}
-
-/**
- * Audit log response.
- *
- * @author Brian Pontarelli
- */
-export interface AuditLogSearchResponse {
-  auditLogs?: Array<AuditLog>;
-  total?: number;
-}
-
-/**
- * @author Daniel DeGroff
- */
-export enum LambdaEngineType {
-  GraalJS = "GraalJS",
-  Nashorn = "Nashorn"
-}
-
-/**
- * API response for starting a WebAuthn authentication ceremony
- *
- * @author Spencer Witt
- */
-export interface WebAuthnStartResponse {
-  options?: PublicKeyCredentialRequestOptions;
-}
-
-/**
- * SAML v2 identity provider configuration.
- *
- * @author Brian Pontarelli
- */
-export interface SAMLv2IdentityProvider extends BaseSAMLv2IdentityProvider<SAMLv2ApplicationConfiguration> {
-  assertionConfiguration?: SAMLv2AssertionConfiguration;
-  buttonImageURL?: string;
-  buttonText?: string;
-  domains?: Array<string>;
-  idpEndpoint?: string;
-  idpInitiatedConfiguration?: SAMLv2IdpInitiatedConfiguration;
-  issuer?: string;
-  loginHintConfiguration?: LoginHintConfiguration;
-  nameIdFormat?: string;
-  postRequest?: boolean;
-  requestSigningKeyId?: UUID;
-  signRequest?: boolean;
-  xmlSignatureC14nMethod?: CanonicalizationMethod;
-}
-
-/**
- * Search request for entity types.
- *
- * @author Brian Pontarelli
- */
-export interface EntityTypeSearchRequest {
-  search?: EntityTypeSearchCriteria;
-}
-
-/**
- * API request for managing families and members.
- *
- * @author Brian Pontarelli
- */
-export interface FamilyRequest {
-  familyMember?: FamilyMember;
-}
-
-// Do not require a setter for 'type', it is defined by the concrete class and is not mutable
-export interface BaseConnectorConfiguration {
-  data?: Record<string, any>;
-  debug?: boolean;
-  id?: UUID;
-  insertInstant?: number;
-  lastUpdateInstant?: number;
-  name?: string;
-  type?: ConnectorType;
-}
-
-/**
- * @author Daniel DeGroff
- */
-export interface ReloadRequest {
-  names?: Array<string>;
-}
-
-/**
- * @author Brett Guy
- */
-export interface TwoFactorStartRequest {
-  applicationId?: UUID;
-  code?: string;
-  loginId?: string;
-  state?: Record<string, any>;
-  trustChallenge?: string;
-  userId?: UUID;
-}
-
-/**
- * @author Daniel DeGroff
- */
-export interface ApplicationMultiFactorConfiguration {
-  email?: MultiFactorEmailTemplate;
-  loginPolicy?: MultiFactorLoginPolicy;
-  sms?: MultiFactorSMSTemplate;
-  trustPolicy?: ApplicationMultiFactorTrustPolicy;
-}
-
-export interface MultiFactorEmailTemplate {
-  templateId?: UUID;
-}
-
-export interface MultiFactorSMSTemplate {
-  templateId?: UUID;
-}
-
-/**
- * @author Daniel DeGroff
- */
-export interface IdentityProviderLinkResponse {
-  identityProviderLink?: IdentityProviderLink;
-  identityProviderLinks?: Array<IdentityProviderLink>;
-}
-
-/**
- * @author Daniel DeGroff
- */
-export interface IssueResponse {
-  refreshToken?: string;
-  token?: string;
-}
-
-/**
- * Request to authenticate with WebAuthn
- *
- * @author Spencer Witt
- */
-export interface WebAuthnPublicKeyAuthenticationRequest {
-  clientExtensionResults?: WebAuthnExtensionsClientOutputs;
-  id?: string;
-  response?: WebAuthnAuthenticatorAuthenticationResponse;
-  rpId?: string;
-  type?: string;
-}
-
-/**
- * Entity API request object.
- *
- * @author Brian Pontarelli
- */
-export interface EntityRequest {
-  entity?: Entity;
-}
-
-/**
- * Models the Group Update Event.
- *
- * @author Daniel DeGroff
- */
-export interface GroupUpdateEvent extends BaseGroupEvent {
-  original?: Group;
-}
-
-/**
- * CleanSpeak configuration at the system and application level.
- *
- * @author Brian Pontarelli
- */
-export interface CleanSpeakConfiguration extends Enableable {
-  apiKey?: string;
-  applicationIds?: Array<UUID>;
-  url?: string;
-  usernameModeration?: UsernameModeration;
-}
-
-export interface UsernameModeration extends Enableable {
-  applicationId?: UUID;
-}
-
-/**
- * Stores an email template used to send emails to users.
- *
- * @author Brian Pontarelli
- */
-export interface EmailTemplate {
-  defaultFromName?: string;
-  defaultHtmlTemplate?: string;
-  defaultSubject?: string;
-  defaultTextTemplate?: string;
-  fromEmail?: string;
-  id?: UUID;
-  insertInstant?: number;
-  lastUpdateInstant?: number;
-  localizedFromNames?: LocalizedStrings;
-  localizedHtmlTemplates?: LocalizedStrings;
-  localizedSubjects?: LocalizedStrings;
-  localizedTextTemplates?: LocalizedStrings;
-  name?: string;
-}
-
-/**
- * API response for managing families and members.
- *
- * @author Brian Pontarelli
- */
-export interface FamilyResponse {
-  families?: Array<Family>;
-  family?: Family;
-}
-
-/**
- * Search response for Group Members
- *
- * @author Daniel DeGroff
- */
-export interface GroupMemberSearchResponse {
-  members?: Array<GroupMember>;
-  total?: number;
-}
-
-/**
- * @author Daniel DeGroff
- */
-export interface BreachedPasswordTenantMetric {
-  actionRequired?: number;
-  matchedCommonPasswordCount?: number;
-  matchedExactCount?: number;
-  matchedPasswordCount?: number;
-  matchedSubAddressCount?: number;
-  passwordsCheckedCount?: number;
-}
-
-/**
- * JWT Configuration. A JWT Configuration for an Application may not be active if it is using the global configuration, the configuration
- * may be <code>enabled = false</code>.
- *
- * @author Daniel DeGroff
- */
-export interface JWTConfiguration extends Enableable {
-  accessTokenKeyId?: UUID;
-  idTokenKeyId?: UUID;
-  refreshTokenExpirationPolicy?: RefreshTokenExpirationPolicy;
-  refreshTokenOneTimeUseConfiguration?: RefreshTokenOneTimeUseConfiguration;
-  refreshTokenRevocationPolicy?: RefreshTokenRevocationPolicy;
-  refreshTokenSlidingWindowConfiguration?: RefreshTokenSlidingWindowConfiguration;
-  refreshTokenTimeToLiveInMinutes?: number;
-  refreshTokenUsagePolicy?: RefreshTokenUsagePolicy;
-  timeToLiveInSeconds?: number;
-}
-
-/**
- * @author Brian Pontarelli
- */
-export interface SAMLv2ApplicationConfiguration extends BaseIdentityProviderApplicationConfiguration {
-  buttonImageURL?: string;
-  buttonText?: string;
-}
-
-/**
- * @author Brett Guy
- */
-export interface MessengerRequest {
-  messenger?: BaseMessengerConfiguration;
-}
-
-/**
- * A log for an action that was taken on a User.
- *
- * @author Brian Pontarelli
- */
-export interface UserActionLog {
-  actioneeUserId?: UUID;
-  actionerUserId?: UUID;
-  applicationIds?: Array<UUID>;
-  comment?: string;
-  emailUserOnEnd?: boolean;
-  endEventSent?: boolean;
-  expiry?: number;
-  history?: LogHistory;
-  id?: UUID;
-  insertInstant?: number;
-  localizedName?: string;
-  localizedOption?: string;
-  localizedReason?: string;
-  name?: string;
-  notifyUserOnEnd?: boolean;
-  option?: string;
-  reason?: string;
-  reasonCode?: string;
-  userActionId?: UUID;
-}
-
-/**
- * Contains extension output for requested extensions during a WebAuthn ceremony
- *
- * @author Spencer Witt
- */
-export interface WebAuthnExtensionsClientOutputs {
-  credProps?: CredentialPropertiesOutput;
-}
-
-/**
- * Describes a user account or WebAuthn Relying Party associated with a public key credential
- */
-export interface PublicKeyCredentialEntity {
-  name?: string;
-}
-
-/**
- * Registration delete API request object.
- *
- * @author Brian Pontarelli
- */
-export interface RegistrationDeleteRequest extends BaseEventRequest {
-}
-
-/**
- * Used to express whether the Relying Party requires <a href="https://www.w3.org/TR/webauthn-2/#user-verification">user verification</a> for the
- * current operation.
- *
- * @author Spencer Witt
- */
-export enum UserVerificationRequirement {
-  required = "required",
-  preferred = "preferred",
-  discouraged = "discouraged"
-}
-
-/**
- * Helper interface that indicates an identity provider can be federated to using the HTTP POST method.
- *
- * @author Brian Pontarelli
- */
-export interface SupportsPostBindings {
-}
-
-/**
- * Search response for Themes
- *
- * @author Mark Manes
- */
-export interface ThemeSearchResponse {
-  themes?: Array<Theme>;
-  total?: number;
-}
-
-/**
- * @author Brian Pontarelli
- */
-export interface AuditLogSearchCriteria extends BaseSearchCriteria {
-  end?: number;
-  message?: string;
-  newValue?: string;
-  oldValue?: string;
-  reason?: string;
-  start?: number;
-  user?: string;
-}
-
-/**
- * @author Daniel DeGroff
- */
-export interface HYPRIdentityProvider extends BaseIdentityProvider<HYPRApplicationConfiguration> {
-  relyingPartyApplicationId?: string;
-  relyingPartyURL?: string;
-}
-
-/**
- * @author Brett Guy
- */
-export enum ClientAuthenticationPolicy {
-  Required = "Required",
-  NotRequired = "NotRequired",
-  NotRequiredWhenUsingPKCE = "NotRequiredWhenUsingPKCE"
-}
-
-/**
- * @author Daniel DeGroff
- */
-export interface PendingIdPLink {
-  displayName?: string;
-  email?: string;
-  identityProviderId?: UUID;
-  identityProviderLinks?: Array<IdentityProviderLink>;
-  identityProviderName?: string;
-  identityProviderTenantConfiguration?: IdentityProviderTenantConfiguration;
-  identityProviderType?: IdentityProviderType;
-  identityProviderUserId?: string;
-  user?: User;
-  username?: string;
-}
-
-/**
- * API response for starting a WebAuthn registration ceremony
- *
- * @author Spencer Witt
- */
-export interface WebAuthnRegisterStartResponse {
-  options?: PublicKeyCredentialCreationOptions;
-}
-
-/**
- * A Application-level policy for deleting Users.
- *
- * @author Trevor Smith
- */
-export interface ApplicationRegistrationDeletePolicy {
-  unverified?: TimeBasedDeletePolicy;
-}
-
-/**
- * @author Daniel DeGroff
- */
-export interface IdentityProviderLimitUserLinkingPolicy extends Enableable {
-  maximumLinks?: number;
-}
-
-/**
- * @author Daniel DeGroff
- */
-export interface ReactorMetricsResponse {
-  metrics?: ReactorMetrics;
-}
-
-/**
- * Search request for IP ACLs .
- *
- * @author Brett Guy
- */
-export interface IPAccessControlListSearchRequest {
-  search?: IPAccessControlListSearchCriteria;
-}
-
-/**
- * @author Daniel DeGroff
- */
-export enum FormType {
-  registration = "registration",
-  adminRegistration = "adminRegistration",
-  adminUser = "adminUser",
-  selfServiceUser = "selfServiceUser"
-}
-
-/**
- * @author Daniel DeGroff
- */
-export interface TenantRequest extends BaseEventRequest {
-  sourceTenantId?: UUID;
-  tenant?: Tenant;
-  webhookIds?: Array<UUID>;
-}
-
-/**
- * User Comment Response
- *
- * @author Seth Musselman
- */
-export interface UserCommentResponse {
-  userComment?: UserComment;
-  userComments?: Array<UserComment>;
-}
-
-/**
- * The reason for the login failure.
- *
- * @author Daniel DeGroff
- */
-export interface UserLoginFailedReason {
-  code?: string;
-  lambdaId?: UUID;
-  lambdaResult?: Errors;
-}
-
-/**
- * Config for regular SAML IDP configurations that support IdP initiated requests
- *
- * @author Lyle Schemmerling
- */
-export interface SAMLv2IdpInitiatedConfiguration extends Enableable {
-  issuer?: string;
-}
-
-/**
- * A Tenant-level policy for deleting Users.
- *
- * @author Trevor Smith
- */
-export interface TenantUserDeletePolicy {
-  unverified?: TimeBasedDeletePolicy;
-}
-
-/**
- * Search request for Group Members.
- *
- * @author Daniel DeGroff
- */
-export interface GroupMemberSearchRequest {
-  search?: GroupMemberSearchCriteria;
-}
-
-/**
- * Group Member Response
- *
- * @author Daniel DeGroff
- */
-export interface MemberResponse {
-  members?: Record<UUID, Array<GroupMember>>;
-}
-
-/**
- * User Action API request object.
- *
- * @author Brian Pontarelli
- */
-export interface UserActionRequest {
-  userAction?: UserAction;
-}
-
-/**
- * Configuration for the behavior of failed login attempts. This helps us protect against brute force password attacks.
- *
- * @author Daniel DeGroff
- */
-export interface FailedAuthenticationConfiguration {
-  actionCancelPolicy?: FailedAuthenticationActionCancelPolicy;
-  actionDuration?: number;
-  actionDurationUnit?: ExpiryUnit;
-  emailUser?: boolean;
-  resetCountInSeconds?: number;
-  tooManyAttempts?: number;
-  userActionId?: UUID;
-}
-
-/**
- * @author Daniel DeGroff
- */
-export interface ApplicationAccessControlConfiguration {
-  uiIPAccessControlListId?: UUID;
-}
-
-/**
- * XML canonicalization method enumeration. This is used for the IdP and SP side of FusionAuth SAML.
- *
- * @author Brian Pontarelli
- */
-export enum CanonicalizationMethod {
-  exclusive = "exclusive",
-  exclusive_with_comments = "exclusive_with_comments",
-  inclusive = "inclusive",
-  inclusive_with_comments = "inclusive_with_comments"
-}
-
-/**
- * Request to complete the WebAuthn registration ceremony
- *
- * @author Spencer Witt
- */
-export interface WebAuthnLoginRequest extends BaseLoginRequest {
-  credential?: WebAuthnPublicKeyAuthenticationRequest;
-  origin?: string;
-  rpId?: string;
-  twoFactorTrustId?: string;
-}
-
-/**
- * @author Brian Pontarelli
- */
-export enum ExpiryUnit {
-  MINUTES = "MINUTES",
-  HOURS = "HOURS",
-  DAYS = "DAYS",
-  WEEKS = "WEEKS",
-  MONTHS = "MONTHS",
-  YEARS = "YEARS"
-}
-
-/**
- * The Application API request object.
- *
- * @author Brian Pontarelli
- */
-export interface ApplicationRequest extends BaseEventRequest {
-  application?: Application;
-  role?: ApplicationRole;
-  sourceApplicationId?: UUID;
-}
-
-/**
- * Webhook API response object.
- *
- * @author Brian Pontarelli
- */
-export interface WebhookResponse {
-  webhook?: Webhook;
-  webhooks?: Array<Webhook>;
-}
-
-/**
- * @author Seth Musselman
- */
-export interface UserCommentRequest {
-  userComment?: UserComment;
-}
-
-/**
- * @author Daniel DeGroff
- */
-export interface SystemLogsExportRequest extends BaseExportRequest {
-  includeArchived?: boolean;
-  lastNBytes?: number;
-}
-
-/**
- * @author Brett Guy
- */
-export interface MessengerResponse {
-  messenger?: BaseMessengerConfiguration;
-  messengers?: Array<BaseMessengerConfiguration>;
-}
-
-/**
- * @author Michael Sleevi
- */
-export interface PreviewMessageTemplateResponse {
-  errors?: Errors;
-  message?: SMSMessage;
-}
-
-/**
- * Search criteria for Applications
- *
- * @author Spencer Witt
- */
-export interface ApplicationSearchCriteria extends BaseSearchCriteria {
-  name?: string;
-  state?: ObjectState;
-  tenantId?: UUID;
-}
-
-/**
- * @author Daniel DeGroff
- */
-export interface OpenIdConnectIdentityProvider extends BaseIdentityProvider<OpenIdConnectApplicationConfiguration> {
-  buttonImageURL?: string;
-  buttonText?: string;
-  domains?: Array<string>;
-  oauth2?: IdentityProviderOauth2Configuration;
-  postRequest?: boolean;
-}
-
-/**
- * Models the User Registration Verified Event.
- *
- * @author Trevor Smith
- */
-export interface UserRegistrationVerifiedEvent extends BaseUserEvent {
-  applicationId?: UUID;
-  registration?: UserRegistration;
-}
-
-/**
- * A Message Template Request to the API
- *
- * @author Michael Sleevi
- */
-export interface MessageTemplateRequest {
-  messageTemplate?: MessageTemplate;
-}
-
-/**
- * @author Daniel DeGroff
- */
-export interface DeviceUserCodeResponse {
-  client_id?: string;
-  deviceInfo?: DeviceInfo;
-  expires_in?: number;
-  pendingIdPLink?: PendingIdPLink;
-  scope?: string;
-  tenantId?: UUID;
-  user_code?: string;
+  servicesId?: string;
+  teamId?: string;
 }
 
 /**
@@ -9598,1176 +5740,6 @@ export interface AppleIdentityProvider extends BaseIdentityProvider<AppleApplica
   scope?: string;
   servicesId?: string;
   teamId?: string;
-}
-
-/**
- * @author Daniel DeGroff
- */
-export interface EmailHeader {
-  name?: string;
-  value?: string;
-}
-
-/**
- * Models the Group Member Remove Complete Event.
- *
- * @author Daniel DeGroff
- */
-export interface GroupMemberRemoveCompleteEvent extends BaseGroupEvent {
-  members?: Array<GroupMember>;
-}
-
-export interface WebhookEventLog {
-  attempts?: Array<WebhookAttemptLog>;
-  data?: Record<string, any>;
-  event?: EventRequest;
-  eventResult?: WebhookEventResult;
-  eventType?: EventType;
-  failedAttempts?: number;
-  id?: UUID;
-  insertInstant?: number;
-  lastAttemptInstant?: number;
-  lastUpdateInstant?: number;
-  linkedObjectId?: UUID;
-  sequence?: number;
-  successfulAttempts?: number;
-}
-
-/**
- * Group API request object.
- *
- * @author Daniel DeGroff
- */
-export interface GroupRequest {
-  group?: Group;
-  roleIds?: Array<UUID>;
-}
-
-/**
- * Search request for entity grants.
- *
- * @author Brian Pontarelli
- */
-export interface EntityGrantSearchRequest {
-  search?: EntityGrantSearchCriteria;
-}
-
-/**
- * Models the User Delete Registration Event.
- *
- * @author Daniel DeGroff
- */
-export interface UserRegistrationDeleteEvent extends BaseUserEvent {
-  applicationId?: UUID;
-  registration?: UserRegistration;
-}
-
-/**
- * Contains attributes for the Relying Party to refer to an existing public key credential as an input parameter.
- *
- * @author Spencer Witt
- */
-export interface PublicKeyCredentialDescriptor {
-  id?: string;
-  transports?: Array<string>;
-  type?: PublicKeyCredentialType;
-}
-
-/**
- * @author Brett Guy
- */
-export interface TwilioMessengerConfiguration extends BaseMessengerConfiguration {
-  accountSID?: string;
-  authToken?: string;
-  fromPhoneNumber?: string;
-  messagingServiceSid?: string;
-  url?: string;
-}
-
-/**
- * @author Daniel DeGroff
- */
-export interface ReactorMetrics {
-  breachedPasswordMetrics?: Record<UUID, BreachedPasswordTenantMetric>;
-}
-
-/**
- * @author Daniel DeGroff
- */
-export interface ApplicationFormConfiguration {
-  adminRegistrationFormId?: UUID;
-  selfServiceFormConfiguration?: SelfServiceFormConfiguration;
-  selfServiceFormId?: UUID;
-}
-
-/**
- * @author Brett Guy
- */
-export interface IPAccessControlListSearchCriteria extends BaseSearchCriteria {
-  name?: string;
-}
-
-/**
- * @author Daniel DeGroff
- */
-export interface RegistrationUnverifiedOptions {
-  behavior?: UnverifiedBehavior;
-}
-
-/**
- * @author Daniel DeGroff
- */
-export interface TenantResponse {
-  tenant?: Tenant;
-  tenants?: Array<Tenant>;
-}
-
-/**
- * Request for the Refresh Token API to revoke a refresh token rather than using the URL parameters.
- *
- * @author Brian Pontarelli
- */
-export interface RefreshTokenRevokeRequest extends BaseEventRequest {
-  applicationId?: UUID;
-  token?: string;
-  userId?: UUID;
-}
-
-/**
- * Models a JWT Refresh Token.
- *
- * @author Daniel DeGroff
- */
-export interface RefreshToken {
-  applicationId?: UUID;
-  data?: Record<string, any>;
-  id?: UUID;
-  insertInstant?: number;
-  metaData?: MetaData;
-  startInstant?: number;
-  tenantId?: UUID;
-  token?: string;
-  userId?: UUID;
-}
-
-export interface MetaData {
-  data?: Record<string, any>;
-  device?: DeviceInfo;
-  scopes?: Array<string>;
-}
-
-/**
- * A marker interface indicating this event is an event that can supply a linked object Id.
- *
- * @author Spencer Witt
- */
-export interface ObjectIdentifiable {
-}
-
-/**
- * Form field response.
- *
- * @author Brett Guy
- */
-export interface FormFieldResponse {
-  field?: FormField;
-  fields?: Array<FormField>;
-}
-
-/**
- * JWT Public Key Response Object
- *
- * @author Daniel DeGroff
- */
-export interface PublicKeyResponse {
-  publicKey?: string;
-  publicKeys?: Record<string, string>;
-}
-
-/**
- * Response for the user login report.
- *
- * @author Seth Musselman
- */
-export interface RecentLoginResponse {
-  logins?: Array<DisplayableRawLogin>;
-}
-
-/**
- * Container for the event information. This is the JSON that is sent from FusionAuth to webhooks.
- *
- * @author Brian Pontarelli
- */
-export interface EventRequest {
-  event?: BaseEvent;
-}
-
-/**
- * @author Daniel DeGroff
- */
-export interface TwoFactorEnableDisableSendRequest {
-  email?: string;
-  method?: string;
-  methodId?: string;
-  mobilePhone?: string;
-}
-
-/**
- * @author Daniel DeGroff
- */
-export enum SecureGeneratorType {
-  randomDigits = "randomDigits",
-  randomBytes = "randomBytes",
-  randomAlpha = "randomAlpha",
-  randomAlphaNumeric = "randomAlphaNumeric"
-}
-
-/**
- * Entity grant API request object.
- *
- * @author Brian Pontarelli
- */
-export interface EntityGrantRequest {
-  grant?: EntityGrant;
-}
-
-/**
- * Models the User Login Failed Event.
- *
- * @author Daniel DeGroff
- */
-export interface UserLoginFailedEvent extends BaseUserEvent {
-  applicationId?: UUID;
-  authenticationType?: string;
-  ipAddress?: string;
-  reason?: UserLoginFailedReason;
-}
-
-/**
- * Search response for Groups
- *
- * @author Daniel DeGroff
- */
-export interface GroupSearchResponse {
-  groups?: Array<Group>;
-  total?: number;
-}
-
-/**
- * Entity Type API request object.
- *
- * @author Brian Pontarelli
- */
-export interface EntityTypeRequest {
-  entityType?: EntityType;
-  permission?: EntityTypePermission;
-}
-
-/**
- * Key search response
- *
- * @author Spencer Witt
- */
-export interface KeySearchResponse {
-  keys?: Array<Key>;
-  total?: number;
-}
-
-/**
- * The handling policy for scopes provided by FusionAuth
- *
- * @author Spencer Witt
- */
-export interface ProvidedScopePolicy {
-  address?: Requirable;
-  email?: Requirable;
-  phone?: Requirable;
-  profile?: Requirable;
-}
-
-/**
- * Models the Group Delete Event.
- *
- * @author Daniel DeGroff
- */
-export interface GroupDeleteEvent extends BaseGroupEvent {
-}
-
-/**
- * @author Daniel DeGroff
- */
-export interface LoginHintConfiguration extends Enableable {
-  parameterName?: string;
-}
-
-/**
- * Supply additional information about the Relying Party when creating a new credential
- *
- * @author Spencer Witt
- */
-export interface PublicKeyCredentialRelyingPartyEntity extends PublicKeyCredentialEntity {
-  id?: string;
-}
-
-/**
- * Search response for entity types.
- *
- * @author Brian Pontarelli
- */
-export interface EntityTypeSearchResponse {
-  entityTypes?: Array<EntityType>;
-  total?: number;
-}
-
-/**
- * Search criteria for webhooks.
- *
- * @author Spencer Witt
- */
-export interface WebhookSearchCriteria extends BaseSearchCriteria {
-  description?: string;
-  tenantId?: UUID;
-  url?: string;
-}
-
-/**
- * Models a set of localized Integers that can be stored as JSON.
- *
- * @author Daniel DeGroff
- */
-export interface LocalizedIntegers extends Record<string, number> {
-}
-
-/**
- * @author Daniel DeGroff
- */
-export interface TenantUnverifiedConfiguration {
-  email?: UnverifiedBehavior;
-  whenGated?: RegistrationUnverifiedOptions;
-}
-
-/**
- * Search request for entity grants.
- *
- * @author Brian Pontarelli
- */
-export interface EntityGrantSearchResponse {
-  grants?: Array<EntityGrant>;
-  total?: number;
-}
-
-/**
- * @author Daniel DeGroff
- */
-export enum FormDataType {
-  bool = "bool",
-  consent = "consent",
-  date = "date",
-  email = "email",
-  number = "number",
-  string = "string"
-}
-
-/**
- * User Action API response object.
- *
- * @author Brian Pontarelli
- */
-export interface UserActionResponse {
-  userAction?: UserAction;
-  userActions?: Array<UserAction>;
-}
-
-/**
- * Search request for Groups.
- *
- * @author Daniel DeGroff
- */
-export interface GroupSearchRequest {
-  search?: GroupSearchCriteria;
-}
-
-/**
- * Authentication key request object.
- *
- * @author Sanjay
- */
-export interface APIKeyRequest {
-  apiKey?: APIKey;
-  sourceKeyId?: UUID;
-}
-
-/**
- * Twitter social login provider.
- *
- * @author Daniel DeGroff
- */
-export interface TwitterIdentityProvider extends BaseIdentityProvider<TwitterApplicationConfiguration> {
-  buttonText?: string;
-  consumerKey?: string;
-  consumerSecret?: string;
-}
-
-/**
- * Lambda API request object.
- *
- * @author Brian Pontarelli
- */
-export interface LambdaRequest {
-  lambda?: Lambda;
-}
-
-/**
- * @author Michael Sleevi
- */
-export interface SMSMessageTemplate extends MessageTemplate {
-  defaultTemplate?: string;
-  localizedTemplates?: LocalizedStrings;
-}
-
-/**
- * Models an event where a user is being created with an "in-use" login Id (email or username).
- *
- * @author Daniel DeGroff
- */
-export interface UserLoginIdDuplicateOnCreateEvent extends BaseUserEvent {
-  duplicateEmail?: string;
-  duplicateUsername?: string;
-  existing?: User;
-}
-
-/**
- * @author Mikey Sleevi
- */
-export interface Message {
-}
-
-/**
- * @author Daniel DeGroff
- */
-export interface RefreshRequest extends BaseEventRequest {
-  refreshToken?: string;
-  token?: string;
-}
-
-/**
- * @author Brian Pontarelli
- */
-export interface TwoFactorRequest extends BaseEventRequest {
-  applicationId?: UUID;
-  authenticatorId?: string;
-  code?: string;
-  email?: string;
-  method?: string;
-  mobilePhone?: string;
-  secret?: string;
-  secretBase32Encoded?: string;
-  twoFactorId?: string;
-}
-
-/**
- * Something that can be required and thus also optional. This currently extends Enableable because anything that is
- * required/optional is almost always enableable as well.
- *
- * @author Brian Pontarelli
- */
-export interface Requirable extends Enableable {
-  required?: boolean;
-}
-
-/**
- * @author Daniel DeGroff
- */
-export interface VerifyEmailResponse {
-  oneTimeCode?: string;
-  verificationId?: string;
-}
-
-/**
- * The global view of a User. This object contains all global information about the user including birthdate, registration information
- * preferred languages, global attributes, etc.
- *
- * @author Seth Musselman
- */
-export interface User extends SecureIdentity {
-  active?: boolean;
-  birthDate?: string;
-  cleanSpeakId?: UUID;
-  data?: Record<string, any>;
-  email?: string;
-  expiry?: number;
-  firstName?: string;
-  fullName?: string;
-  imageUrl?: string;
-  insertInstant?: number;
-  lastName?: string;
-  lastUpdateInstant?: number;
-  memberships?: Array<GroupMember>;
-  middleName?: string;
-  mobilePhone?: string;
-  parentEmail?: string;
-  preferredLanguages?: Array<string>;
-  registrations?: Array<UserRegistration>;
-  tenantId?: UUID;
-  timezone?: string;
-  twoFactor?: UserTwoFactorConfiguration;
-}
-
-/**
- * @author Daniel DeGroff
- */
-export interface BaseLoginRequest extends BaseEventRequest {
-  applicationId?: UUID;
-  ipAddress?: string;
-  metaData?: MetaData;
-  newDevice?: boolean;
-  noJWT?: boolean;
-}
-
-/**
- * @author Daniel DeGroff
- */
-export interface KafkaConfiguration extends Enableable {
-  defaultTopic?: string;
-  producer?: Record<string, string>;
-}
-
-/**
- * @author Daniel DeGroff
- */
-export interface PasswordlessLoginRequest extends BaseLoginRequest {
-  code?: string;
-  twoFactorTrustId?: string;
-}
-
-/**
- * Models the User Update Event once it is completed. This cannot be transactional.
- *
- * @author Daniel DeGroff
- */
-export interface UserUpdateCompleteEvent extends BaseUserEvent {
-  original?: User;
-}
-
-/**
- * Models the User Update Event.
- *
- * @author Brian Pontarelli
- */
-export interface UserUpdateEvent extends BaseUserEvent {
-  original?: User;
-}
-
-/**
- * Entity API response object.
- *
- * @author Brian Pontarelli
- */
-export interface EntityResponse {
-  entity?: Entity;
-}
-
-/**
- * Used by the Relying Party to specify their requirements for authenticator attributes. Fields use the deprecated "resident key" terminology to refer
- * to client-side discoverable credentials to maintain backwards compatibility with WebAuthn Level 1.
- *
- * @author Spencer Witt
- */
-export interface AuthenticatorSelectionCriteria {
-  authenticatorAttachment?: AuthenticatorAttachment;
-  requireResidentKey?: boolean;
-  residentKey?: ResidentKeyRequirement;
-  userVerification?: UserVerificationRequirement;
-}
-
-/**
- * Events that are bound to applications.
- *
- * @author Brian Pontarelli
- */
-export interface ApplicationEvent {
-}
-
-/**
- * API request for sending out family requests to parent's.
- *
- * @author Brian Pontarelli
- */
-export interface FamilyEmailRequest {
-  parentEmail?: string;
-}
-
-/**
- * Refresh Token Import request.
- *
- * @author Brett Guy
- */
-export interface RefreshTokenImportRequest {
-  refreshTokens?: Array<RefreshToken>;
-  validateDbConstraints?: boolean;
-}
-
-/**
- * The IdP behavior when no user link has been made yet.
- *
- * @author Daniel DeGroff
- */
-export enum IdentityProviderLinkingStrategy {
-  CreatePendingLink = "CreatePendingLink",
-  Disabled = "Disabled",
-  LinkAnonymously = "LinkAnonymously",
-  LinkByEmail = "LinkByEmail",
-  LinkByEmailForExistingUser = "LinkByEmailForExistingUser",
-  LinkByUsername = "LinkByUsername",
-  LinkByUsernameForExistingUser = "LinkByUsernameForExistingUser",
-  Unsupported = "Unsupported"
-}
-
-/**
- * @author Daniel DeGroff
- */
-export enum MultiFactorLoginPolicy {
-  Disabled = "Disabled",
-  Enabled = "Enabled",
-  Required = "Required"
-}
-
-/**
- * @author Daniel DeGroff
- */
-export interface IdentityProviderLinkRequest extends BaseEventRequest {
-  identityProviderLink?: IdentityProviderLink;
-  pendingIdPLinkId?: string;
-}
-
-/**
- * Google social login provider.
- *
- * @author Daniel DeGroff
- */
-export interface GoogleIdentityProvider extends BaseIdentityProvider<GoogleApplicationConfiguration> {
-  buttonText?: string;
-  client_id?: string;
-  client_secret?: string;
-  loginMethod?: IdentityProviderLoginMethod;
-  properties?: GoogleIdentityProviderProperties;
-  scope?: string;
-}
-
-/**
- * Group Member Request
- *
- * @author Daniel DeGroff
- */
-export interface MemberRequest {
-  members?: Record<UUID, Array<GroupMember>>;
-}
-
-/**
- * Email template response.
- *
- * @author Brian Pontarelli
- */
-export interface EmailTemplateResponse {
-  emailTemplate?: EmailTemplate;
-  emailTemplates?: Array<EmailTemplate>;
-}
-
-/**
- * @author Brett Guy
- */
-export enum IPAccessControlEntryAction {
-  Allow = "Allow",
-  Block = "Block"
-}
-
-/**
- * Key API response object.
- *
- * @author Daniel DeGroff
- */
-export interface KeyResponse {
-  key?: Key;
-  keys?: Array<Key>;
-}
-
-/**
- * Search criteria for Keys
- *
- * @author Spencer Witt
- */
-export interface KeySearchCriteria extends BaseSearchCriteria {
-  algorithm?: KeyAlgorithm;
-  name?: string;
-  type?: KeyType;
-}
-
-/**
- * Stores an message template used to distribute messages;
- *
- * @author Michael Sleevi
- */
-export interface MessageTemplate {
-  data?: Record<string, any>;
-  id?: UUID;
-  insertInstant?: number;
-  lastUpdateInstant?: number;
-  name?: string;
-  type?: MessageType;
-}
-
-/**
- * Models the User Reactivate Event.
- *
- * @author Brian Pontarelli
- */
-export interface UserReactivateEvent extends BaseUserEvent {
-}
-
-/**
- * @author Daniel DeGroff
- */
-export interface FormField {
-  confirm?: boolean;
-  consentId?: UUID;
-  control?: FormControl;
-  data?: Record<string, any>;
-  description?: string;
-  id?: UUID;
-  insertInstant?: number;
-  key?: string;
-  lastUpdateInstant?: number;
-  name?: string;
-  options?: Array<string>;
-  required?: boolean;
-  type?: FormDataType;
-  validator?: FormFieldValidator;
-}
-
-/**
- * Search request for Applications
- *
- * @author Spencer Witt
- */
-export interface ApplicationSearchRequest extends ExpandableRequest {
-  search?: ApplicationSearchCriteria;
-}
-
-/**
- * Type for webhook headers.
- *
- * @author Brian Pontarelli
- */
-export interface HTTPHeaders extends Record<string, string> {
-}
-
-/**
- * A custom OAuth scope for a specific application.
- *
- * @author Spencer Witt
- */
-export interface ApplicationOAuthScope {
-  applicationId?: UUID;
-  data?: Record<string, any>;
-  defaultConsentDetail?: string;
-  defaultConsentMessage?: string;
-  description?: string;
-  id?: UUID;
-  insertInstant?: number;
-  lastUpdateInstant?: number;
-  name?: string;
-  required?: boolean;
-}
-
-/**
- * Models the Group Create Complete Event.
- *
- * @author Daniel DeGroff
- */
-export interface GroupDeleteCompleteEvent extends BaseGroupEvent {
-}
-
-/**
- * Models the JWT Refresh Event. This event will be fired when a JWT is "refreshed" (generated) using a Refresh Token.
- *
- * @author Daniel DeGroff
- */
-export interface JWTRefreshEvent extends BaseEvent {
-  applicationId?: UUID;
-  original?: string;
-  refreshToken?: string;
-  token?: string;
-  userId?: UUID;
-}
-
-/**
- * @author Brett Pontarelli
- */
-export interface TenantCaptchaConfiguration extends Enableable {
-  captchaMethod?: CaptchaMethod;
-  secretKey?: string;
-  siteKey?: string;
-  threshold?: number;
-}
-
-/**
- * @author Daniel DeGroff
- */
-export interface LoginRecordSearchRequest {
-  retrieveTotal?: boolean;
-  search?: LoginRecordSearchCriteria;
-}
-
-/**
- * Models the User Create Event.
- *
- * @author Brian Pontarelli
- */
-export interface UserCreateEvent extends BaseUserEvent {
-}
-
-/**
- * User Action Reason API request object.
- *
- * @author Brian Pontarelli
- */
-export interface UserActionReasonRequest {
-  userActionReason?: UserActionReason;
-}
-
-/**
- * @author Lyle Schemmerling
- */
-export interface BaseSAMLv2IdentityProvider<D extends BaseIdentityProviderApplicationConfiguration> extends BaseIdentityProvider<D> {
-  assertionDecryptionConfiguration?: SAMLv2AssertionDecryptionConfiguration;
-  emailClaim?: string;
-  keyId?: UUID;
-  uniqueIdClaim?: string;
-  useNameIdForEmail?: boolean;
-  usernameClaim?: string;
-}
-
-/**
- * Options to request extensions during credential registration
- *
- * @author Spencer Witt
- */
-export interface WebAuthnRegistrationExtensionOptions {
-  credProps?: boolean;
-}
-
-/**
- * @author Daniel DeGroff
- */
-export interface AccessToken {
-  access_token?: string;
-  expires_in?: number;
-  id_token?: string;
-  refresh_token?: string;
-  refresh_token_id?: UUID;
-  scope?: string;
-  token_type?: TokenType;
-  userId?: UUID;
-}
-
-/**
- * Search API response.
- *
- * @author Brian Pontarelli
- */
-export interface SearchResponse extends ExpandableResponse {
-  nextResults?: string;
-  total?: number;
-  users?: Array<User>;
-}
-
-/**
- * @author Daniel DeGroff
- */
-export interface SendResponse {
-  anonymousResults?: Record<string, EmailTemplateErrors>;
-  results?: Record<UUID, EmailTemplateErrors>;
-}
-
-export interface EmailTemplateErrors {
-  parseErrors?: Record<string, string>;
-  renderErrors?: Record<string, string>;
-}
-
-/**
- * The phases of a time-based user action.
- *
- * @author Brian Pontarelli
- */
-export enum UserActionPhase {
-  start = "start",
-  modify = "modify",
-  cancel = "cancel",
-  end = "end"
-}
-
-/**
- * @author Daniel DeGroff
- */
-export interface RememberPreviousPasswords extends Enableable {
-  count?: number;
-}
-
-/**
- * The types of lambdas that indicate how they are invoked by FusionAuth.
- *
- * @author Brian Pontarelli
- */
-export enum LambdaType {
-  JWTPopulate = "JWTPopulate",
-  OpenIDReconcile = "OpenIDReconcile",
-  SAMLv2Reconcile = "SAMLv2Reconcile",
-  SAMLv2Populate = "SAMLv2Populate",
-  AppleReconcile = "AppleReconcile",
-  ExternalJWTReconcile = "ExternalJWTReconcile",
-  FacebookReconcile = "FacebookReconcile",
-  GoogleReconcile = "GoogleReconcile",
-  HYPRReconcile = "HYPRReconcile",
-  TwitterReconcile = "TwitterReconcile",
-  LDAPConnectorReconcile = "LDAPConnectorReconcile",
-  LinkedInReconcile = "LinkedInReconcile",
-  EpicGamesReconcile = "EpicGamesReconcile",
-  NintendoReconcile = "NintendoReconcile",
-  SonyPSNReconcile = "SonyPSNReconcile",
-  SteamReconcile = "SteamReconcile",
-  TwitchReconcile = "TwitchReconcile",
-  XboxReconcile = "XboxReconcile",
-  ClientCredentialsJWTPopulate = "ClientCredentialsJWTPopulate",
-  SCIMServerGroupRequestConverter = "SCIMServerGroupRequestConverter",
-  SCIMServerGroupResponseConverter = "SCIMServerGroupResponseConverter",
-  SCIMServerUserRequestConverter = "SCIMServerUserRequestConverter",
-  SCIMServerUserResponseConverter = "SCIMServerUserResponseConverter",
-  SelfServiceRegistrationValidation = "SelfServiceRegistrationValidation",
-  UserInfoPopulate = "UserInfoPopulate",
-  LoginValidation = "LoginValidation"
-}
-
-/**
- * The <i>authenticator's</i> response for the registration ceremony in its encoded format
- *
- * @author Spencer Witt
- */
-export interface WebAuthnAuthenticatorRegistrationResponse {
-  attestationObject?: string;
-  clientDataJSON?: string;
-}
-
-/**
- * A marker interface indicating this event is not scoped to a tenant and will be sent to all webhooks.
- *
- * @author Daniel DeGroff
- */
-export interface InstanceEvent extends NonTransactionalEvent {
-}
-
-/**
- * API request to import an existing WebAuthn credential(s)
- *
- * @author Spencer Witt
- */
-export interface WebAuthnCredentialImportRequest {
-  credentials?: Array<WebAuthnCredential>;
-  validateDbConstraints?: boolean;
-}
-
-/**
- * Configuration for signing webhooks.
- *
- * @author Brent Halsey
- */
-export interface WebhookSignatureConfiguration extends Enableable {
-  signingKeyId?: UUID;
-}
-
-/**
- * @author Daniel DeGroff
- */
-export interface PasswordlessStartRequest {
-  applicationId?: UUID;
-  loginId?: string;
-  state?: Record<string, any>;
-}
-
-/**
- * API response for retrieving Refresh Tokens
- *
- * @author Daniel DeGroff
- */
-export interface RefreshTokenResponse {
-  refreshToken?: RefreshToken;
-  refreshTokens?: Array<RefreshToken>;
-}
-
-/**
- * Registration API request object.
- *
- * @author Brian Pontarelli
- */
-export interface RegistrationRequest extends BaseEventRequest {
-  disableDomainBlock?: boolean;
-  generateAuthenticationToken?: boolean;
-  registration?: UserRegistration;
-  sendSetPasswordEmail?: boolean;
-  skipRegistrationVerification?: boolean;
-  skipVerification?: boolean;
-  user?: User;
-}
-
-/**
- * @author Daniel DeGroff
- */
-export enum SystemTrustedProxyConfigurationPolicy {
-  All = "All",
-  OnlyConfigured = "OnlyConfigured"
-}
-
-/**
- * Request for managing FusionAuth Reactor and licenses.
- *
- * @author Brian Pontarelli
- */
-export interface ReactorRequest {
-  license?: string;
-  licenseId?: string;
-}
-
-/**
- * Search results.
- *
- * @author Brian Pontarelli
- */
-export interface SearchResults<T> {
-  nextResults?: string;
-  results?: Array<T>;
-  total?: number;
-  totalEqualToActual?: boolean;
-}
-
-/**
- * Response for the daily active user report.
- *
- * @author Brian Pontarelli
- */
-export interface DailyActiveUserReportResponse {
-  dailyActiveUsers?: Array<Count>;
-  total?: number;
-}
-
-/**
- * SAML v2 IdP Initiated identity provider configuration.
- *
- * @author Daniel DeGroff
- */
-export interface SAMLv2IdPInitiatedIdentityProvider extends BaseSAMLv2IdentityProvider<SAMLv2IdPInitiatedApplicationConfiguration> {
-  issuer?: string;
-}
-
-/**
- * @author Daniel DeGroff
- */
-export interface DeviceApprovalResponse {
-  deviceGrantStatus?: string;
-  deviceInfo?: DeviceInfo;
-  identityProviderLink?: IdentityProviderLink;
-  tenantId?: UUID;
-  userId?: UUID;
-}
-
-/**
- * @author Daniel DeGroff
- */
-export interface UserTwoFactorConfiguration {
-  methods?: Array<TwoFactorMethod>;
-  recoveryCodes?: Array<string>;
-}
-
-/**
- * Search request for email templates
- *
- * @author Mark Manes
- */
-export interface EmailTemplateSearchRequest {
-  search?: EmailTemplateSearchCriteria;
-}
-
-/**
- * The summary of the action that is preventing login to be returned on the login response.
- *
- * @author Daniel DeGroff
- */
-export interface LoginPreventedResponse {
-  actionerUserId?: UUID;
-  actionId?: UUID;
-  expiry?: number;
-  localizedName?: string;
-  localizedOption?: string;
-  localizedReason?: string;
-  name?: string;
-  option?: string;
-  reason?: string;
-  reasonCode?: string;
-}
-
-/**
- * Models content user action options.
- *
- * @author Brian Pontarelli
- */
-export interface UserActionOption {
-  localizedNames?: LocalizedStrings;
-  name?: string;
-}
-
-/**
- * Event log response.
- *
- * @author Daniel DeGroff
- */
-export interface EventLogResponse {
-  eventLog?: EventLog;
-}
-
-/**
- * @author Daniel DeGroff
- */
-export interface SAMLv2IdPInitiatedApplicationConfiguration extends BaseIdentityProviderApplicationConfiguration {
-}
-
-/**
- * @author andrewpai
- */
-export interface SelfServiceFormConfiguration {
-  requireCurrentPasswordOnPasswordChange?: boolean;
-}
-
-/**
- * Models the Group Update Complete Event.
- *
- * @author Daniel DeGroff
- */
-export interface GroupUpdateCompleteEvent extends BaseGroupEvent {
-  original?: Group;
-}
-
-/**
- * Reindex API request
- *
- * @author Daniel DeGroff
- */
-export interface ReindexRequest {
-  index?: string;
-}
-
-/**
- * @author Daniel DeGroff
- */
-export interface ApplicationExternalIdentifierConfiguration {
-  twoFactorTrustIdTimeToLiveInSeconds?: number;
 }
 
 /**
@@ -10891,11 +5863,6 @@ export enum SAMLLogoutBehavior {
   OnlyOriginator = "OnlyOriginator"
 }
 
-export enum XMLSignatureLocation {
-  Assertion = "Assertion",
-  Response = "Response"
-}
-
 export interface SAMLv2AssertionEncryptionConfiguration extends Enableable {
   digestAlgorithm?: string;
   encryptionAlgorithm?: string;
@@ -10920,6 +5887,3762 @@ export interface SAMLv2SingleLogout extends Enableable {
   xmlSignatureC14nMethod?: CanonicalizationMethod;
 }
 
+export enum XMLSignatureLocation {
+  Assertion = "Assertion",
+  Response = "Response"
+}
+
+/**
+ * @author Daniel DeGroff
+ */
+export interface ApplicationAccessControlConfiguration {
+  uiIPAccessControlListId?: UUID;
+}
+
+/**
+ * Events that are bound to applications.
+ *
+ * @author Brian Pontarelli
+ */
+export interface ApplicationEvent {
+}
+
+/**
+ * @author Daniel DeGroff
+ */
+export interface ApplicationExternalIdentifierConfiguration {
+  twoFactorTrustIdTimeToLiveInSeconds?: number;
+}
+
+/**
+ * @author Daniel DeGroff
+ */
+export interface ApplicationFormConfiguration {
+  adminRegistrationFormId?: UUID;
+  selfServiceFormConfiguration?: SelfServiceFormConfiguration;
+  selfServiceFormId?: UUID;
+}
+
+/**
+ * @author Daniel DeGroff
+ */
+export interface ApplicationMultiFactorConfiguration {
+  email?: MultiFactorEmailTemplate;
+  loginPolicy?: MultiFactorLoginPolicy;
+  sms?: MultiFactorSMSTemplate;
+  trustPolicy?: ApplicationMultiFactorTrustPolicy;
+}
+
+export interface MultiFactorEmailTemplate {
+  templateId?: UUID;
+}
+
+export interface MultiFactorSMSTemplate {
+  templateId?: UUID;
+}
+
+/**
+ * @author Daniel DeGroff
+ */
+export enum ApplicationMultiFactorTrustPolicy {
+  Any = "Any",
+  This = "This",
+  None = "None"
+}
+
+/**
+ * A custom OAuth scope for a specific application.
+ *
+ * @author Spencer Witt
+ */
+export interface ApplicationOAuthScope {
+  applicationId?: UUID;
+  data?: Record<string, any>;
+  defaultConsentDetail?: string;
+  defaultConsentMessage?: string;
+  description?: string;
+  id?: UUID;
+  insertInstant?: number;
+  lastUpdateInstant?: number;
+  name?: string;
+  required?: boolean;
+}
+
+/**
+ * The Application Scope API request object.
+ *
+ * @author Spencer Witt
+ */
+export interface ApplicationOAuthScopeRequest {
+  scope?: ApplicationOAuthScope;
+}
+
+/**
+ * The Application Scope API response.
+ *
+ * @author Spencer Witt
+ */
+export interface ApplicationOAuthScopeResponse {
+  scope?: ApplicationOAuthScope;
+}
+
+/**
+ * A Application-level policy for deleting Users.
+ *
+ * @author Trevor Smith
+ */
+export interface ApplicationRegistrationDeletePolicy {
+  unverified?: TimeBasedDeletePolicy;
+}
+
+/**
+ * The Application API request object.
+ *
+ * @author Brian Pontarelli
+ */
+export interface ApplicationRequest extends BaseEventRequest {
+  application?: Application;
+  role?: ApplicationRole;
+  sourceApplicationId?: UUID;
+}
+
+/**
+ * The Application API response.
+ *
+ * @author Brian Pontarelli
+ */
+export interface ApplicationResponse {
+  application?: Application;
+  applications?: Array<Application>;
+  role?: ApplicationRole;
+}
+
+/**
+ * A role given to a user for a specific application.
+ *
+ * @author Seth Musselman
+ */
+export interface ApplicationRole {
+  description?: string;
+  id?: UUID;
+  insertInstant?: number;
+  isDefault?: boolean;
+  isSuperRole?: boolean;
+  lastUpdateInstant?: number;
+  name?: string;
+}
+
+/**
+ * Search criteria for Applications
+ *
+ * @author Spencer Witt
+ */
+export interface ApplicationSearchCriteria extends BaseSearchCriteria {
+  name?: string;
+  state?: ObjectState;
+  tenantId?: UUID;
+}
+
+/**
+ * Search request for Applications
+ *
+ * @author Spencer Witt
+ */
+export interface ApplicationSearchRequest extends ExpandableRequest {
+  search?: ApplicationSearchCriteria;
+}
+
+/**
+ * Application search response
+ *
+ * @author Spencer Witt
+ */
+export interface ApplicationSearchResponse extends ExpandableResponse {
+  applications?: Array<Application>;
+  total?: number;
+}
+
+/**
+ * Application-level configuration for WebAuthn
+ *
+ * @author Daniel DeGroff
+ */
+export interface ApplicationWebAuthnConfiguration extends Enableable {
+  bootstrapWorkflow?: ApplicationWebAuthnWorkflowConfiguration;
+  reauthenticationWorkflow?: ApplicationWebAuthnWorkflowConfiguration;
+}
+
+/**
+ * @author Daniel DeGroff
+ */
+export interface ApplicationWebAuthnWorkflowConfiguration extends Enableable {
+}
+
+/**
+ * This class is a simple attachment with a byte array, name and MIME type.
+ *
+ * @author Brian Pontarelli
+ */
+export interface Attachment {
+  attachment?: Array<number>;
+  mime?: string;
+  name?: string;
+}
+
+/**
+ * Used to communicate whether and how authenticator attestation should be delivered to the Relying Party
+ *
+ * @author Spencer Witt
+ */
+export enum AttestationConveyancePreference {
+  none = "none",
+  indirect = "indirect",
+  direct = "direct",
+  enterprise = "enterprise"
+}
+
+/**
+ * Used to indicate what type of attestation was included in the authenticator response for a given WebAuthn credential at the time it was created
+ *
+ * @author Spencer Witt
+ */
+export enum AttestationType {
+  basic = "basic",
+  self = "self",
+  attestationCa = "attestationCa",
+  anonymizationCa = "anonymizationCa",
+  none = "none"
+}
+
+/**
+ * An audit log.
+ *
+ * @author Brian Pontarelli
+ */
+export interface AuditLog {
+  data?: Record<string, any>;
+  id?: number;
+  insertInstant?: number;
+  insertUser?: string;
+  message?: string;
+  newValue?: any;
+  oldValue?: any;
+  reason?: string;
+}
+
+/**
+ * Event to indicate an audit log was created.
+ *
+ * @author Daniel DeGroff
+ */
+export interface AuditLogCreateEvent extends BaseEvent {
+  auditLog?: AuditLog;
+}
+
+/**
+ * @author Daniel DeGroff
+ */
+export interface AuditLogExportRequest extends BaseExportRequest {
+  criteria?: AuditLogSearchCriteria;
+}
+
+/**
+ * @author Brian Pontarelli
+ */
+export interface AuditLogRequest extends BaseEventRequest {
+  auditLog?: AuditLog;
+}
+
+/**
+ * Audit log response.
+ *
+ * @author Brian Pontarelli
+ */
+export interface AuditLogResponse {
+  auditLog?: AuditLog;
+}
+
+/**
+ * @author Brian Pontarelli
+ */
+export interface AuditLogSearchCriteria extends BaseSearchCriteria {
+  end?: number;
+  message?: string;
+  newValue?: string;
+  oldValue?: string;
+  reason?: string;
+  start?: number;
+  user?: string;
+}
+
+/**
+ * @author Brian Pontarelli
+ */
+export interface AuditLogSearchRequest {
+  search?: AuditLogSearchCriteria;
+}
+
+/**
+ * Audit log response.
+ *
+ * @author Brian Pontarelli
+ */
+export interface AuditLogSearchResponse {
+  auditLogs?: Array<AuditLog>;
+  total?: number;
+}
+
+/**
+ * @author Brett Pontarelli
+ */
+export enum AuthenticationThreats {
+  ImpossibleTravel = "ImpossibleTravel"
+}
+
+/**
+ * Describes the <a href="https://www.w3.org/TR/webauthn-2/#authenticator-attachment-modality">authenticator attachment modality</a>.
+ *
+ * @author Spencer Witt
+ */
+export enum AuthenticatorAttachment {
+  platform = "platform",
+  crossPlatform = "crossPlatform"
+}
+
+/**
+ * Describes the authenticator attachment modality preference for a WebAuthn workflow. See {@link AuthenticatorAttachment}
+ *
+ * @author Spencer Witt
+ */
+export enum AuthenticatorAttachmentPreference {
+  any = "any",
+  platform = "platform",
+  crossPlatform = "crossPlatform"
+}
+
+/**
+ * @author Daniel DeGroff
+ */
+export interface AuthenticatorConfiguration {
+  algorithm?: TOTPAlgorithm;
+  codeLength?: number;
+  timeStep?: number;
+}
+
+export enum TOTPAlgorithm {
+  HmacSHA1 = "HmacSHA1",
+  HmacSHA256 = "HmacSHA256",
+  HmacSHA512 = "HmacSHA512"
+}
+
+/**
+ * Used by the Relying Party to specify their requirements for authenticator attributes. Fields use the deprecated "resident key" terminology to refer
+ * to client-side discoverable credentials to maintain backwards compatibility with WebAuthn Level 1.
+ *
+ * @author Spencer Witt
+ */
+export interface AuthenticatorSelectionCriteria {
+  authenticatorAttachment?: AuthenticatorAttachment;
+  requireResidentKey?: boolean;
+  residentKey?: ResidentKeyRequirement;
+  userVerification?: UserVerificationRequirement;
+}
+
+// Do not require a setter for 'type', it is defined by the concrete class and is not mutable
+export interface BaseConnectorConfiguration {
+  data?: Record<string, any>;
+  debug?: boolean;
+  id?: UUID;
+  insertInstant?: number;
+  lastUpdateInstant?: number;
+  name?: string;
+  type?: ConnectorType;
+}
+
+/**
+ * @author Brian Pontarelli
+ */
+export interface BaseElasticSearchCriteria extends BaseSearchCriteria {
+  accurateTotal?: boolean;
+  ids?: Array<UUID>;
+  nextResults?: string;
+  query?: string;
+  queryString?: string;
+  sortFields?: Array<SortField>;
+}
+
+/**
+ * Base class for all FusionAuth events.
+ *
+ * @author Brian Pontarelli
+ */
+export interface BaseEvent {
+  createInstant?: number;
+  id?: UUID;
+  info?: EventInfo;
+  tenantId?: UUID;
+  type?: EventType;
+}
+
+/**
+ * Base class for requests that can contain event information. This event information is used when sending Webhooks or emails
+ * during the transaction. The caller is responsible for ensuring that the event information is correct.
+ *
+ * @author Brian Pontarelli
+ */
+export interface BaseEventRequest {
+  eventInfo?: EventInfo;
+}
+
+/**
+ * @author Daniel DeGroff
+ */
+export interface BaseExportRequest {
+  dateTimeSecondsFormat?: string;
+  zoneId?: string;
+}
+
+/**
+ * Base class for all {@link Group} and {@link GroupMember} events.
+ *
+ * @author Spencer Witt
+ */
+export interface BaseGroupEvent extends BaseEvent {
+  group?: Group;
+}
+
+// Do not require a setter for 'type', it is defined by the concrete class and is not mutable
+export interface BaseIdentityProvider<D extends BaseIdentityProviderApplicationConfiguration> extends Enableable {
+  applicationConfiguration?: Record<UUID, D>;
+  data?: Record<string, any>;
+  debug?: boolean;
+  id?: UUID;
+  insertInstant?: number;
+  lambdaConfiguration?: LambdaConfiguration;
+  lastUpdateInstant?: number;
+  linkingStrategy?: IdentityProviderLinkingStrategy;
+  name?: string;
+  tenantConfiguration?: Record<UUID, IdentityProviderTenantConfiguration>;
+  type?: IdentityProviderType;
+}
+
+export interface LambdaConfiguration {
+  reconcileId?: UUID;
+}
+
+/**
+ * @author Daniel DeGroff
+ */
+export interface BaseIdentityProviderApplicationConfiguration extends Enableable {
+  createRegistration?: boolean;
+  data?: Record<string, any>;
+}
+
+/**
+ * @author Daniel DeGroff
+ */
+export interface BaseLoginRequest extends BaseEventRequest {
+  applicationId?: UUID;
+  ipAddress?: string;
+  metaData?: MetaData;
+  newDevice?: boolean;
+  noJWT?: boolean;
+}
+
+// Do not require a setter for 'type', it is defined by the concrete class and is not mutable
+export interface BaseMessengerConfiguration {
+  data?: Record<string, any>;
+  debug?: boolean;
+  id?: UUID;
+  insertInstant?: number;
+  lastUpdateInstant?: number;
+  name?: string;
+  transport?: string;
+  type?: MessengerType;
+}
+
+/**
+ * @author Lyle Schemmerling
+ */
+export interface BaseSAMLv2IdentityProvider<D extends BaseIdentityProviderApplicationConfiguration> extends BaseIdentityProvider<D> {
+  assertionDecryptionConfiguration?: SAMLv2AssertionDecryptionConfiguration;
+  emailClaim?: string;
+  keyId?: UUID;
+  uniqueIdClaim?: string;
+  useNameIdForEmail?: boolean;
+  usernameClaim?: string;
+}
+
+/**
+ * @author Brian Pontarelli
+ */
+export interface BaseSearchCriteria {
+  numberOfResults?: number;
+  orderBy?: string;
+  startRow?: number;
+}
+
+/**
+ * Base class for all {@link User}-related events.
+ *
+ * @author Spencer Witt
+ */
+export interface BaseUserEvent extends BaseEvent {
+  user?: User;
+}
+
+/**
+ * @author Daniel DeGroff
+ */
+export enum BreachedPasswordStatus {
+  None = "None",
+  ExactMatch = "ExactMatch",
+  SubAddressMatch = "SubAddressMatch",
+  PasswordOnly = "PasswordOnly",
+  CommonPassword = "CommonPassword"
+}
+
+/**
+ * @author Daniel DeGroff
+ */
+export interface BreachedPasswordTenantMetric {
+  actionRequired?: number;
+  matchedCommonPasswordCount?: number;
+  matchedExactCount?: number;
+  matchedPasswordCount?: number;
+  matchedSubAddressCount?: number;
+  passwordsCheckedCount?: number;
+}
+
+/**
+ * @author Trevor Smith
+ */
+export interface CORSConfiguration extends Enableable {
+  allowCredentials?: boolean;
+  allowedHeaders?: Array<string>;
+  allowedMethods?: Array<HTTPMethod>;
+  allowedOrigins?: Array<string>;
+  debug?: boolean;
+  exposedHeaders?: Array<string>;
+  preflightMaxAgeInSeconds?: number;
+}
+
+/**
+ * XML canonicalization method enumeration. This is used for the IdP and SP side of FusionAuth SAML.
+ *
+ * @author Brian Pontarelli
+ */
+export enum CanonicalizationMethod {
+  exclusive = "exclusive",
+  exclusive_with_comments = "exclusive_with_comments",
+  inclusive = "inclusive",
+  inclusive_with_comments = "inclusive_with_comments"
+}
+
+/**
+ * @author Brett Pontarelli
+ */
+export enum CaptchaMethod {
+  GoogleRecaptchaV2 = "GoogleRecaptchaV2",
+  GoogleRecaptchaV3 = "GoogleRecaptchaV3",
+  HCaptcha = "HCaptcha",
+  HCaptchaEnterprise = "HCaptchaEnterprise"
+}
+
+/**
+ * @author Trevor Smith
+ */
+export enum ChangePasswordReason {
+  Administrative = "Administrative",
+  Breached = "Breached",
+  Expired = "Expired",
+  Validation = "Validation"
+}
+
+/**
+ * Change password request object.
+ *
+ * @author Brian Pontarelli
+ */
+export interface ChangePasswordRequest extends BaseEventRequest {
+  applicationId?: UUID;
+  changePasswordId?: string;
+  currentPassword?: string;
+  loginId?: string;
+  password?: string;
+  refreshToken?: string;
+  trustChallenge?: string;
+  trustToken?: string;
+}
+
+/**
+ * Change password response object.
+ *
+ * @author Daniel DeGroff
+ */
+export interface ChangePasswordResponse {
+  oneTimePassword?: string;
+  state?: Record<string, any>;
+}
+
+/**
+ * CleanSpeak configuration at the system and application level.
+ *
+ * @author Brian Pontarelli
+ */
+export interface CleanSpeakConfiguration extends Enableable {
+  apiKey?: string;
+  applicationIds?: Array<UUID>;
+  url?: string;
+  usernameModeration?: UsernameModeration;
+}
+
+export interface UsernameModeration extends Enableable {
+  applicationId?: UUID;
+}
+
+/**
+ * @author Brett Guy
+ */
+export enum ClientAuthenticationPolicy {
+  Required = "Required",
+  NotRequired = "NotRequired",
+  NotRequiredWhenUsingPKCE = "NotRequiredWhenUsingPKCE"
+}
+
+/**
+ * @author Trevor Smith
+ */
+export interface ConnectorPolicy {
+  connectorId?: UUID;
+  data?: Record<string, any>;
+  domains?: Array<string>;
+  migrate?: boolean;
+}
+
+/**
+ * @author Trevor Smith
+ */
+export interface ConnectorRequest {
+  connector?: BaseConnectorConfiguration;
+}
+
+/**
+ * @author Trevor Smith
+ */
+export interface ConnectorResponse {
+  connector?: BaseConnectorConfiguration;
+  connectors?: Array<BaseConnectorConfiguration>;
+}
+
+/**
+ * The types of connectors. This enum is stored as an ordinal on the <code>identities</code> table, order must be maintained.
+ *
+ * @author Trevor Smith
+ */
+export enum ConnectorType {
+  FusionAuth = "FusionAuth",
+  Generic = "Generic",
+  LDAP = "LDAP"
+}
+
+/**
+ * Models a consent.
+ *
+ * @author Daniel DeGroff
+ */
+export interface Consent {
+  consentEmailTemplateId?: UUID;
+  countryMinimumAgeForSelfConsent?: LocalizedIntegers;
+  data?: Record<string, any>;
+  defaultMinimumAgeForSelfConsent?: number;
+  emailPlus?: EmailPlus;
+  id?: UUID;
+  insertInstant?: number;
+  lastUpdateInstant?: number;
+  multipleValuesAllowed?: boolean;
+  name?: string;
+  values?: Array<string>;
+}
+
+export interface EmailPlus extends Enableable {
+  emailTemplateId?: UUID;
+  maximumTimeToSendEmailInHours?: number;
+  minimumTimeToSendEmailInHours?: number;
+}
+
+/**
+ * API request for User consent types.
+ *
+ * @author Daniel DeGroff
+ */
+export interface ConsentRequest {
+  consent?: Consent;
+}
+
+/**
+ * API response for consent.
+ *
+ * @author Daniel DeGroff
+ */
+export interface ConsentResponse {
+  consent?: Consent;
+  consents?: Array<Consent>;
+}
+
+/**
+ * Search criteria for Consents
+ *
+ * @author Spencer Witt
+ */
+export interface ConsentSearchCriteria extends BaseSearchCriteria {
+  name?: string;
+}
+
+/**
+ * Search request for Consents
+ *
+ * @author Spencer Witt
+ */
+export interface ConsentSearchRequest {
+  search?: ConsentSearchCriteria;
+}
+
+/**
+ * Consent search response
+ *
+ * @author Spencer Witt
+ */
+export interface ConsentSearchResponse {
+  consents?: Array<Consent>;
+  total?: number;
+}
+
+/**
+ * Models a consent.
+ *
+ * @author Daniel DeGroff
+ */
+export enum ConsentStatus {
+  Active = "Active",
+  Revoked = "Revoked"
+}
+
+/**
+ * Status for content like usernames, profile attributes, etc.
+ *
+ * @author Brian Pontarelli
+ */
+export enum ContentStatus {
+  ACTIVE = "ACTIVE",
+  PENDING = "PENDING",
+  REJECTED = "REJECTED"
+}
+
+/**
+ * A number identifying a cryptographic algorithm. Values should be registered with the <a
+ * href="https://www.iana.org/assignments/cose/cose.xhtml#algorithms">IANA COSE Algorithms registry</a>
+ *
+ * @author Spencer Witt
+ */
+export enum CoseAlgorithmIdentifier {
+  ES256 = "SHA256withECDSA",
+  ES384 = "SHA384withECDSA",
+  ES512 = "SHA512withECDSA",
+  RS256 = "SHA256withRSA",
+  RS384 = "SHA384withRSA",
+  RS512 = "SHA512withRSA",
+  PS256 = "SHA-256",
+  PS384 = "SHA-384",
+  PS512 = "SHA-512"
+}
+
+/**
+ * COSE Elliptic Curve identifier to determine which elliptic curve to use with a given key
+ *
+ * @author Spencer Witt
+ */
+export enum CoseEllipticCurve {
+  Reserved = "Reserved",
+  P256 = "P256",
+  P384 = "P384",
+  P521 = "P521",
+  X25519 = "X25519",
+  X448 = "X448",
+  Ed25519 = "Ed25519",
+  Ed448 = "Ed448",
+  Secp256k1 = "Secp256k1"
+}
+
+/**
+ * COSE key type
+ *
+ * @author Spencer Witt
+ */
+export enum CoseKeyType {
+  Reserved = "0",
+  OKP = "1",
+  EC2 = "2",
+  RSA = "3",
+  Symmetric = "4"
+}
+
+/**
+ * @author Brian Pontarelli
+ */
+export interface Count {
+  count?: number;
+  interval?: number;
+}
+
+/**
+ * Contains the output for the {@code credProps} extension
+ *
+ * @author Spencer Witt
+ */
+export interface CredentialPropertiesOutput {
+  rk?: boolean;
+}
+
+/**
+ * Response for the daily active user report.
+ *
+ * @author Brian Pontarelli
+ */
+export interface DailyActiveUserReportResponse {
+  dailyActiveUsers?: Array<Count>;
+  total?: number;
+}
+
+/**
+ * @author Daniel DeGroff
+ */
+export interface DeviceApprovalResponse {
+  deviceGrantStatus?: string;
+  deviceInfo?: DeviceInfo;
+  identityProviderLink?: IdentityProviderLink;
+  tenantId?: UUID;
+  userId?: UUID;
+}
+
+/**
+ * @author Daniel DeGroff
+ */
+export interface DeviceInfo {
+  description?: string;
+  lastAccessedAddress?: string;
+  lastAccessedInstant?: number;
+  name?: string;
+  type?: string;
+}
+
+export enum DeviceType {
+  BROWSER = "BROWSER",
+  DESKTOP = "DESKTOP",
+  LAPTOP = "LAPTOP",
+  MOBILE = "MOBILE",
+  OTHER = "OTHER",
+  SERVER = "SERVER",
+  TABLET = "TABLET",
+  TV = "TV",
+  UNKNOWN = "UNKNOWN"
+}
+
+/**
+ * @author Trevor Smith
+ */
+export interface DeviceResponse {
+  device_code?: string;
+  expires_in?: number;
+  interval?: number;
+  user_code?: string;
+  verification_uri?: string;
+  verification_uri_complete?: string;
+}
+
+/**
+ * @author Daniel DeGroff
+ */
+export interface DeviceUserCodeResponse {
+  client_id?: string;
+  deviceInfo?: DeviceInfo;
+  expires_in?: number;
+  pendingIdPLink?: PendingIdPLink;
+  scope?: string;
+  tenantId?: UUID;
+  user_code?: string;
+}
+
+/**
+ * A displayable raw login that includes application name and user loginId.
+ *
+ * @author Brian Pontarelli
+ */
+export interface DisplayableRawLogin extends RawLogin {
+  applicationName?: string;
+  location?: Location;
+  loginId?: string;
+}
+
+/**
+ * Interface for all identity providers that can be domain based.
+ */
+export interface DomainBasedIdentityProvider {
+}
+
+/**
+ * This class is an abstraction of a simple email message.
+ *
+ * @author Brian Pontarelli
+ */
+export interface Email {
+  attachments?: Array<Attachment>;
+  bcc?: Array<EmailAddress>;
+  cc?: Array<EmailAddress>;
+  from?: EmailAddress;
+  html?: string;
+  replyTo?: EmailAddress;
+  subject?: string;
+  text?: string;
+  to?: Array<EmailAddress>;
+}
+
+/**
+ * An email address.
+ *
+ * @author Brian Pontarelli
+ */
+export interface EmailAddress {
+  address?: string;
+  display?: string;
+}
+
+/**
+ * @author Brian Pontarelli
+ */
+export interface EmailConfiguration {
+  additionalHeaders?: Array<EmailHeader>;
+  debug?: boolean;
+  defaultFromEmail?: string;
+  defaultFromName?: string;
+  emailUpdateEmailTemplateId?: UUID;
+  emailVerifiedEmailTemplateId?: UUID;
+  forgotPasswordEmailTemplateId?: UUID;
+  host?: string;
+  implicitEmailVerificationAllowed?: boolean;
+  loginIdInUseOnCreateEmailTemplateId?: UUID;
+  loginIdInUseOnUpdateEmailTemplateId?: UUID;
+  loginNewDeviceEmailTemplateId?: UUID;
+  loginSuspiciousEmailTemplateId?: UUID;
+  password?: string;
+  passwordlessEmailTemplateId?: UUID;
+  passwordResetSuccessEmailTemplateId?: UUID;
+  passwordUpdateEmailTemplateId?: UUID;
+  port?: number;
+  properties?: string;
+  security?: EmailSecurityType;
+  setPasswordEmailTemplateId?: UUID;
+  twoFactorMethodAddEmailTemplateId?: UUID;
+  twoFactorMethodRemoveEmailTemplateId?: UUID;
+  unverified?: EmailUnverifiedOptions;
+  username?: string;
+  verificationEmailTemplateId?: UUID;
+  verificationStrategy?: VerificationStrategy;
+  verifyEmail?: boolean;
+  verifyEmailWhenChanged?: boolean;
+}
+
+export enum EmailSecurityType {
+  NONE = "NONE",
+  SSL = "SSL",
+  TLS = "TLS"
+}
+
+/**
+ * @author Daniel DeGroff
+ */
+export interface EmailHeader {
+  name?: string;
+  value?: string;
+}
+
+/**
+ * Stores an email template used to send emails to users.
+ *
+ * @author Brian Pontarelli
+ */
+export interface EmailTemplate {
+  defaultFromName?: string;
+  defaultHtmlTemplate?: string;
+  defaultSubject?: string;
+  defaultTextTemplate?: string;
+  fromEmail?: string;
+  id?: UUID;
+  insertInstant?: number;
+  lastUpdateInstant?: number;
+  localizedFromNames?: LocalizedStrings;
+  localizedHtmlTemplates?: LocalizedStrings;
+  localizedSubjects?: LocalizedStrings;
+  localizedTextTemplates?: LocalizedStrings;
+  name?: string;
+}
+
+/**
+ * Email template request.
+ *
+ * @author Brian Pontarelli
+ */
+export interface EmailTemplateRequest {
+  emailTemplate?: EmailTemplate;
+}
+
+/**
+ * Email template response.
+ *
+ * @author Brian Pontarelli
+ */
+export interface EmailTemplateResponse {
+  emailTemplate?: EmailTemplate;
+  emailTemplates?: Array<EmailTemplate>;
+}
+
+/**
+ * Search criteria for Email templates
+ *
+ * @author Mark Manes
+ */
+export interface EmailTemplateSearchCriteria extends BaseSearchCriteria {
+  name?: string;
+}
+
+/**
+ * Search request for email templates
+ *
+ * @author Mark Manes
+ */
+export interface EmailTemplateSearchRequest {
+  search?: EmailTemplateSearchCriteria;
+}
+
+/**
+ * Email template search response
+ *
+ * @author Mark Manes
+ */
+export interface EmailTemplateSearchResponse {
+  emailTemplates?: Array<EmailTemplate>;
+  total?: number;
+}
+
+/**
+ * @author Daniel DeGroff
+ */
+export interface EmailUnverifiedOptions {
+  allowEmailChangeWhenGated?: boolean;
+  behavior?: UnverifiedBehavior;
+}
+
+/**
+ * Something that can be enabled and thus also disabled.
+ *
+ * @author Daniel DeGroff
+ */
+export interface Enableable {
+  enabled?: boolean;
+}
+
+/**
+ * Models an entity that a user can be granted permissions to. Or an entity that can be granted permissions to another entity.
+ *
+ * @author Brian Pontarelli
+ */
+export interface Entity {
+  clientId?: string;
+  clientSecret?: string;
+  data?: Record<string, any>;
+  id?: UUID;
+  insertInstant?: number;
+  lastUpdateInstant?: number;
+  name?: string;
+  parentId?: UUID;
+  tenantId?: UUID;
+  type?: EntityType;
+}
+
+/**
+ * A grant for an entity to a user or another entity.
+ *
+ * @author Brian Pontarelli
+ */
+export interface EntityGrant {
+  data?: Record<string, any>;
+  entity?: Entity;
+  id?: UUID;
+  insertInstant?: number;
+  lastUpdateInstant?: number;
+  permissions?: Array<string>;
+  recipientEntityId?: UUID;
+  userId?: UUID;
+}
+
+/**
+ * Entity grant API request object.
+ *
+ * @author Brian Pontarelli
+ */
+export interface EntityGrantRequest {
+  grant?: EntityGrant;
+}
+
+/**
+ * Entity grant API response object.
+ *
+ * @author Brian Pontarelli
+ */
+export interface EntityGrantResponse {
+  grant?: EntityGrant;
+  grants?: Array<EntityGrant>;
+}
+
+/**
+ * Search criteria for entity grants.
+ *
+ * @author Brian Pontarelli
+ */
+export interface EntityGrantSearchCriteria extends BaseSearchCriteria {
+  entityId?: UUID;
+  name?: string;
+  userId?: UUID;
+}
+
+/**
+ * Search request for entity grants.
+ *
+ * @author Brian Pontarelli
+ */
+export interface EntityGrantSearchRequest {
+  search?: EntityGrantSearchCriteria;
+}
+
+/**
+ * Search request for entity grants.
+ *
+ * @author Brian Pontarelli
+ */
+export interface EntityGrantSearchResponse {
+  grants?: Array<EntityGrant>;
+  total?: number;
+}
+
+/**
+ * Entity API request object.
+ *
+ * @author Brian Pontarelli
+ */
+export interface EntityRequest {
+  entity?: Entity;
+}
+
+/**
+ * Entity API response object.
+ *
+ * @author Brian Pontarelli
+ */
+export interface EntityResponse {
+  entity?: Entity;
+}
+
+/**
+ * This class is the entity query. It provides a build pattern as well as public fields for use on forms and in actions.
+ *
+ * @author Brian Pontarelli
+ */
+export interface EntitySearchCriteria extends BaseElasticSearchCriteria {
+}
+
+/**
+ * Search request for entities
+ *
+ * @author Brett Guy
+ */
+export interface EntitySearchRequest {
+  search?: EntitySearchCriteria;
+}
+
+/**
+ * Search request for entities
+ *
+ * @author Brett Guy
+ */
+export interface EntitySearchResponse {
+  entities?: Array<Entity>;
+  nextResults?: string;
+  total?: number;
+}
+
+/**
+ * Models an entity type that has a specific set of permissions. These are global objects and can be used across tenants.
+ *
+ * @author Brian Pontarelli
+ */
+export interface EntityType {
+  data?: Record<string, any>;
+  id?: UUID;
+  insertInstant?: number;
+  jwtConfiguration?: EntityJWTConfiguration;
+  lastUpdateInstant?: number;
+  name?: string;
+  permissions?: Array<EntityTypePermission>;
+}
+
+/**
+ * JWT Configuration for entities.
+ */
+export interface EntityJWTConfiguration extends Enableable {
+  accessTokenKeyId?: UUID;
+  timeToLiveInSeconds?: number;
+}
+
+/**
+ * Models a specific entity type permission. This permission can be granted to users or other entities.
+ *
+ * @author Brian Pontarelli
+ */
+export interface EntityTypePermission {
+  data?: Record<string, any>;
+  description?: string;
+  id?: UUID;
+  insertInstant?: number;
+  isDefault?: boolean;
+  lastUpdateInstant?: number;
+  name?: string;
+}
+
+/**
+ * Entity Type API request object.
+ *
+ * @author Brian Pontarelli
+ */
+export interface EntityTypeRequest {
+  entityType?: EntityType;
+  permission?: EntityTypePermission;
+}
+
+/**
+ * Entity Type API response object.
+ *
+ * @author Brian Pontarelli
+ */
+export interface EntityTypeResponse {
+  entityType?: EntityType;
+  entityTypes?: Array<EntityType>;
+  permission?: EntityTypePermission;
+}
+
+/**
+ * Search criteria for entity types.
+ *
+ * @author Brian Pontarelli
+ */
+export interface EntityTypeSearchCriteria extends BaseSearchCriteria {
+  name?: string;
+}
+
+/**
+ * Search request for entity types.
+ *
+ * @author Brian Pontarelli
+ */
+export interface EntityTypeSearchRequest {
+  search?: EntityTypeSearchCriteria;
+}
+
+/**
+ * Search response for entity types.
+ *
+ * @author Brian Pontarelli
+ */
+export interface EntityTypeSearchResponse {
+  entityTypes?: Array<EntityType>;
+  total?: number;
+}
+
+/**
+ * @author Brett Pontarelli
+ */
+export interface EpicGamesApplicationConfiguration extends BaseIdentityProviderApplicationConfiguration {
+  buttonText?: string;
+  client_id?: string;
+  client_secret?: string;
+  scope?: string;
+}
+
+/**
+ * Epic gaming login provider.
+ *
+ * @author Brett Pontarelli
+ */
+export interface EpicGamesIdentityProvider extends BaseIdentityProvider<EpicGamesApplicationConfiguration> {
+  buttonText?: string;
+  client_id?: string;
+  client_secret?: string;
+  scope?: string;
+}
+
+/**
+ * Defines an error.
+ *
+ * @author Brian Pontarelli
+ */
+export interface Error {
+  code?: string;
+  data?: Record<string, any>;
+  message?: string;
+}
+
+/**
+ * Standard error domain object that can also be used as the response from an API call.
+ *
+ * @author Brian Pontarelli
+ */
+export interface Errors {
+  fieldErrors?: Record<string, Array<Error>>;
+  generalErrors?: Array<Error>;
+}
+
+/**
+ * @author Brian Pontarelli
+ */
+export interface EventConfiguration {
+  events?: Record<EventType, EventConfigurationData>;
+}
+
+export interface EventConfigurationData extends Enableable {
+  transactionType?: TransactionType;
+}
+
+/**
+ * Information about a user event (login, register, etc) that helps identify the source of the event (location, device type, OS, etc).
+ *
+ * @author Brian Pontarelli
+ */
+export interface EventInfo {
+  data?: Record<string, any>;
+  deviceDescription?: string;
+  deviceName?: string;
+  deviceType?: string;
+  ipAddress?: string;
+  location?: Location;
+  os?: string;
+  userAgent?: string;
+}
+
+/**
+ * Event log used internally by FusionAuth to help developers debug hooks, Webhooks, email templates, etc.
+ *
+ * @author Brian Pontarelli
+ */
+export interface EventLog {
+  id?: number;
+  insertInstant?: number;
+  message?: string;
+  type?: EventLogType;
+}
+
+/**
+ * An Event "event" to indicate an event log was created.
+ *
+ * @author Daniel DeGroff
+ */
+export interface EventLogCreateEvent extends BaseEvent {
+  eventLog?: EventLog;
+}
+
+/**
+ * Event log response.
+ *
+ * @author Daniel DeGroff
+ */
+export interface EventLogResponse {
+  eventLog?: EventLog;
+}
+
+/**
+ * Search criteria for the event log.
+ *
+ * @author Brian Pontarelli
+ */
+export interface EventLogSearchCriteria extends BaseSearchCriteria {
+  end?: number;
+  message?: string;
+  start?: number;
+  type?: EventLogType;
+}
+
+/**
+ * @author Brian Pontarelli
+ */
+export interface EventLogSearchRequest {
+  search?: EventLogSearchCriteria;
+}
+
+/**
+ * Event log response.
+ *
+ * @author Brian Pontarelli
+ */
+export interface EventLogSearchResponse {
+  eventLogs?: Array<EventLog>;
+  total?: number;
+}
+
+/**
+ * Event Log Type
+ *
+ * @author Daniel DeGroff
+ */
+export enum EventLogType {
+  Information = "Information",
+  Debug = "Debug",
+  Error = "Error"
+}
+
+/**
+ * Container for the event information. This is the JSON that is sent from FusionAuth to webhooks.
+ *
+ * @author Brian Pontarelli
+ */
+export interface EventRequest {
+  event?: BaseEvent;
+}
+
+/**
+ * Models the event types that FusionAuth produces.
+ *
+ * @author Brian Pontarelli
+ */
+export enum EventType {
+  JWTPublicKeyUpdate = "jwt.public-key.update",
+  JWTRefreshTokenRevoke = "jwt.refresh-token.revoke",
+  JWTRefresh = "jwt.refresh",
+  AuditLogCreate = "audit-log.create",
+  EventLogCreate = "event-log.create",
+  KickstartSuccess = "kickstart.success",
+  GroupCreate = "group.create",
+  GroupCreateComplete = "group.create.complete",
+  GroupDelete = "group.delete",
+  GroupDeleteComplete = "group.delete.complete",
+  GroupMemberAdd = "group.member.add",
+  GroupMemberAddComplete = "group.member.add.complete",
+  GroupMemberRemove = "group.member.remove",
+  GroupMemberRemoveComplete = "group.member.remove.complete",
+  GroupMemberUpdate = "group.member.update",
+  GroupMemberUpdateComplete = "group.member.update.complete",
+  GroupUpdate = "group.update",
+  GroupUpdateComplete = "group.update.complete",
+  UserAction = "user.action",
+  UserBulkCreate = "user.bulk.create",
+  UserCreate = "user.create",
+  UserCreateComplete = "user.create.complete",
+  UserDeactivate = "user.deactivate",
+  UserDelete = "user.delete",
+  UserDeleteComplete = "user.delete.complete",
+  UserEmailUpdate = "user.email.update",
+  UserEmailVerified = "user.email.verified",
+  UserIdentityProviderLink = "user.identity-provider.link",
+  UserIdentityProviderUnlink = "user.identity-provider.unlink",
+  UserLoginIdDuplicateOnCreate = "user.loginId.duplicate.create",
+  UserLoginIdDuplicateOnUpdate = "user.loginId.duplicate.update",
+  UserLoginFailed = "user.login.failed",
+  UserLoginNewDevice = "user.login.new-device",
+  UserLoginSuccess = "user.login.success",
+  UserLoginSuspicious = "user.login.suspicious",
+  UserPasswordBreach = "user.password.breach",
+  UserPasswordResetSend = "user.password.reset.send",
+  UserPasswordResetStart = "user.password.reset.start",
+  UserPasswordResetSuccess = "user.password.reset.success",
+  UserPasswordUpdate = "user.password.update",
+  UserReactivate = "user.reactivate",
+  UserRegistrationCreate = "user.registration.create",
+  UserRegistrationCreateComplete = "user.registration.create.complete",
+  UserRegistrationDelete = "user.registration.delete",
+  UserRegistrationDeleteComplete = "user.registration.delete.complete",
+  UserRegistrationUpdate = "user.registration.update",
+  UserRegistrationUpdateComplete = "user.registration.update.complete",
+  UserRegistrationVerified = "user.registration.verified",
+  UserTwoFactorMethodAdd = "user.two-factor.method.add",
+  UserTwoFactorMethodRemove = "user.two-factor.method.remove",
+  UserUpdate = "user.update",
+  UserUpdateComplete = "user.update.complete",
+  Test = "test"
+}
+
+/**
+ * An expandable API request.
+ *
+ * @author Daniel DeGroff
+ */
+export interface ExpandableRequest {
+  expand?: Array<string>;
+}
+
+/**
+ * An expandable API response.
+ *
+ * @author Daniel DeGroff
+ */
+export interface ExpandableResponse {
+  expandable?: Array<string>;
+}
+
+/**
+ * @author Brian Pontarelli
+ */
+export enum ExpiryUnit {
+  MINUTES = "MINUTES",
+  HOURS = "HOURS",
+  DAYS = "DAYS",
+  WEEKS = "WEEKS",
+  MONTHS = "MONTHS",
+  YEARS = "YEARS"
+}
+
+/**
+ * @author Daniel DeGroff
+ */
+export interface ExternalIdentifierConfiguration {
+  authorizationGrantIdTimeToLiveInSeconds?: number;
+  changePasswordIdGenerator?: SecureGeneratorConfiguration;
+  changePasswordIdTimeToLiveInSeconds?: number;
+  deviceCodeTimeToLiveInSeconds?: number;
+  deviceUserCodeIdGenerator?: SecureGeneratorConfiguration;
+  emailVerificationIdGenerator?: SecureGeneratorConfiguration;
+  emailVerificationIdTimeToLiveInSeconds?: number;
+  emailVerificationOneTimeCodeGenerator?: SecureGeneratorConfiguration;
+  externalAuthenticationIdTimeToLiveInSeconds?: number;
+  loginIntentTimeToLiveInSeconds?: number;
+  oneTimePasswordTimeToLiveInSeconds?: number;
+  passwordlessLoginGenerator?: SecureGeneratorConfiguration;
+  passwordlessLoginTimeToLiveInSeconds?: number;
+  pendingAccountLinkTimeToLiveInSeconds?: number;
+  registrationVerificationIdGenerator?: SecureGeneratorConfiguration;
+  registrationVerificationIdTimeToLiveInSeconds?: number;
+  registrationVerificationOneTimeCodeGenerator?: SecureGeneratorConfiguration;
+  rememberOAuthScopeConsentChoiceTimeToLiveInSeconds?: number;
+  samlv2AuthNRequestIdTimeToLiveInSeconds?: number;
+  setupPasswordIdGenerator?: SecureGeneratorConfiguration;
+  setupPasswordIdTimeToLiveInSeconds?: number;
+  trustTokenTimeToLiveInSeconds?: number;
+  twoFactorIdTimeToLiveInSeconds?: number;
+  twoFactorOneTimeCodeIdGenerator?: SecureGeneratorConfiguration;
+  twoFactorOneTimeCodeIdTimeToLiveInSeconds?: number;
+  twoFactorTrustIdTimeToLiveInSeconds?: number;
+  webAuthnAuthenticationChallengeTimeToLiveInSeconds?: number;
+  webAuthnRegistrationChallengeTimeToLiveInSeconds?: number;
+}
+
+/**
+ * @author Daniel DeGroff
+ */
+export interface ExternalJWTApplicationConfiguration extends BaseIdentityProviderApplicationConfiguration {
+}
+
+/**
+ * External JWT-only identity provider.
+ *
+ * @author Daniel DeGroff and Brian Pontarelli
+ */
+export interface ExternalJWTIdentityProvider extends BaseIdentityProvider<ExternalJWTApplicationConfiguration> {
+  claimMap?: Record<string, string>;
+  defaultKeyId?: UUID;
+  domains?: Array<string>;
+  headerKeyParameter?: string;
+  oauth2?: IdentityProviderOauth2Configuration;
+  uniqueIdentityClaim?: string;
+}
+
+/**
+ * @author Daniel DeGroff
+ */
+export interface FacebookApplicationConfiguration extends BaseIdentityProviderApplicationConfiguration {
+  appId?: string;
+  buttonText?: string;
+  client_secret?: string;
+  fields?: string;
+  loginMethod?: IdentityProviderLoginMethod;
+  permissions?: string;
+}
+
+/**
+ * Facebook social login provider.
+ *
+ * @author Brian Pontarelli
+ */
+export interface FacebookIdentityProvider extends BaseIdentityProvider<FacebookApplicationConfiguration> {
+  appId?: string;
+  buttonText?: string;
+  client_secret?: string;
+  fields?: string;
+  loginMethod?: IdentityProviderLoginMethod;
+  permissions?: string;
+}
+
+/**
+ * A policy to configure if and when the user-action is canceled prior to the expiration of the action.
+ *
+ * @author Daniel DeGroff
+ */
+export interface FailedAuthenticationActionCancelPolicy {
+  onPasswordReset?: boolean;
+}
+
+/**
+ * Configuration for the behavior of failed login attempts. This helps us protect against brute force password attacks.
+ *
+ * @author Daniel DeGroff
+ */
+export interface FailedAuthenticationConfiguration {
+  actionCancelPolicy?: FailedAuthenticationActionCancelPolicy;
+  actionDuration?: number;
+  actionDurationUnit?: ExpiryUnit;
+  emailUser?: boolean;
+  resetCountInSeconds?: number;
+  tooManyAttempts?: number;
+  userActionId?: UUID;
+}
+
+/**
+ * Models a family grouping of users.
+ *
+ * @author Brian Pontarelli
+ */
+export interface Family {
+  id?: UUID;
+  insertInstant?: number;
+  lastUpdateInstant?: number;
+  members?: Array<FamilyMember>;
+}
+
+/**
+ * @author Brian Pontarelli
+ */
+export interface FamilyConfiguration extends Enableable {
+  allowChildRegistrations?: boolean;
+  confirmChildEmailTemplateId?: UUID;
+  deleteOrphanedAccounts?: boolean;
+  deleteOrphanedAccountsDays?: number;
+  familyRequestEmailTemplateId?: UUID;
+  maximumChildAge?: number;
+  minimumOwnerAge?: number;
+  parentEmailRequired?: boolean;
+  parentRegistrationEmailTemplateId?: UUID;
+}
+
+/**
+ * API request for sending out family requests to parent's.
+ *
+ * @author Brian Pontarelli
+ */
+export interface FamilyEmailRequest {
+  parentEmail?: string;
+}
+
+/**
+ * Models a single family member.
+ *
+ * @author Brian Pontarelli
+ */
+export interface FamilyMember {
+  data?: Record<string, any>;
+  insertInstant?: number;
+  lastUpdateInstant?: number;
+  owner?: boolean;
+  role?: FamilyRole;
+  userId?: UUID;
+}
+
+export enum FamilyRole {
+  Child = "Child",
+  Teen = "Teen",
+  Adult = "Adult"
+}
+
+/**
+ * API request for managing families and members.
+ *
+ * @author Brian Pontarelli
+ */
+export interface FamilyRequest {
+  familyMember?: FamilyMember;
+}
+
+/**
+ * API response for managing families and members.
+ *
+ * @author Brian Pontarelli
+ */
+export interface FamilyResponse {
+  families?: Array<Family>;
+  family?: Family;
+}
+
+/**
+ * Forgot password request object.
+ *
+ * @author Brian Pontarelli
+ */
+export interface ForgotPasswordRequest extends BaseEventRequest {
+  applicationId?: UUID;
+  changePasswordId?: string;
+  email?: string;
+  loginId?: string;
+  sendForgotPasswordEmail?: boolean;
+  state?: Record<string, any>;
+  username?: string;
+}
+
+/**
+ * Forgot password response object.
+ *
+ * @author Daniel DeGroff
+ */
+export interface ForgotPasswordResponse {
+  changePasswordId?: string;
+}
+
+/**
+ * @author Daniel DeGroff
+ */
+export interface Form {
+  data?: Record<string, any>;
+  id?: UUID;
+  insertInstant?: number;
+  lastUpdateInstant?: number;
+  name?: string;
+  steps?: Array<FormStep>;
+  type?: FormType;
+}
+
+/**
+ * @author Daniel DeGroff
+ */
+export enum FormControl {
+  checkbox = "checkbox",
+  number = "number",
+  password = "password",
+  radio = "radio",
+  select = "select",
+  textarea = "textarea",
+  text = "text"
+}
+
+/**
+ * @author Daniel DeGroff
+ */
+export enum FormDataType {
+  bool = "bool",
+  consent = "consent",
+  date = "date",
+  email = "email",
+  number = "number",
+  string = "string"
+}
+
+/**
+ * @author Daniel DeGroff
+ */
+export interface FormField {
+  confirm?: boolean;
+  consentId?: UUID;
+  control?: FormControl;
+  data?: Record<string, any>;
+  description?: string;
+  id?: UUID;
+  insertInstant?: number;
+  key?: string;
+  lastUpdateInstant?: number;
+  name?: string;
+  options?: Array<string>;
+  required?: boolean;
+  type?: FormDataType;
+  validator?: FormFieldValidator;
+}
+
+/**
+ * @author Daniel DeGroff
+ */
+export enum FormFieldAdminPolicy {
+  Edit = "Edit",
+  View = "View"
+}
+
+/**
+ * The FormField API request object.
+ *
+ * @author Brett Guy
+ */
+export interface FormFieldRequest {
+  field?: FormField;
+  fields?: Array<FormField>;
+}
+
+/**
+ * Form field response.
+ *
+ * @author Brett Guy
+ */
+export interface FormFieldResponse {
+  field?: FormField;
+  fields?: Array<FormField>;
+}
+
+/**
+ * @author Daniel DeGroff
+ */
+export interface FormFieldValidator extends Enableable {
+  expression?: string;
+}
+
+/**
+ * Form response.
+ *
+ * @author Daniel DeGroff
+ */
+export interface FormRequest {
+  form?: Form;
+}
+
+/**
+ * Form response.
+ *
+ * @author Daniel DeGroff
+ */
+export interface FormResponse {
+  form?: Form;
+  forms?: Array<Form>;
+}
+
+/**
+ * @author Daniel DeGroff
+ */
+export interface FormStep {
+  fields?: Array<UUID>;
+}
+
+/**
+ * @author Daniel DeGroff
+ */
+export enum FormType {
+  registration = "registration",
+  adminRegistration = "adminRegistration",
+  adminUser = "adminUser",
+  selfServiceUser = "selfServiceUser"
+}
+
+/**
+ * Models the FusionAuth connector.
+ *
+ * @author Trevor Smith
+ */
+export interface FusionAuthConnectorConfiguration extends BaseConnectorConfiguration {
+}
+
+/**
+ * Models a generic connector.
+ *
+ * @author Trevor Smith
+ */
+export interface GenericConnectorConfiguration extends BaseConnectorConfiguration {
+  authenticationURL?: string;
+  connectTimeout?: number;
+  headers?: HTTPHeaders;
+  httpAuthenticationPassword?: string;
+  httpAuthenticationUsername?: string;
+  readTimeout?: number;
+  sslCertificateKeyId?: UUID;
+}
+
+/**
+ * @author Brett Guy
+ */
+export interface GenericMessengerConfiguration extends BaseMessengerConfiguration {
+  connectTimeout?: number;
+  headers?: HTTPHeaders;
+  httpAuthenticationPassword?: string;
+  httpAuthenticationUsername?: string;
+  readTimeout?: number;
+  sslCertificate?: string;
+  url?: string;
+}
+
+/**
+ * @author Daniel DeGroff
+ */
+export interface GoogleApplicationConfiguration extends BaseIdentityProviderApplicationConfiguration {
+  buttonText?: string;
+  client_id?: string;
+  client_secret?: string;
+  loginMethod?: IdentityProviderLoginMethod;
+  properties?: GoogleIdentityProviderProperties;
+  scope?: string;
+}
+
+/**
+ * Google social login provider.
+ *
+ * @author Daniel DeGroff
+ */
+export interface GoogleIdentityProvider extends BaseIdentityProvider<GoogleApplicationConfiguration> {
+  buttonText?: string;
+  client_id?: string;
+  client_secret?: string;
+  loginMethod?: IdentityProviderLoginMethod;
+  properties?: GoogleIdentityProviderProperties;
+  scope?: string;
+}
+
+/**
+ * Google social login provider parameters.
+ *
+ * @author Daniel DeGroff
+ */
+export interface GoogleIdentityProviderProperties {
+  api?: string;
+  button?: string;
+}
+
+/**
+ * Authorization Grant types as defined by the <a href="https://tools.ietf.org/html/rfc6749">The OAuth 2.0 Authorization
+ * Framework - RFC 6749</a>.
+ * <p>
+ * Specific names as defined by <a href="https://tools.ietf.org/html/rfc7591#section-4.1">
+ * OAuth 2.0 Dynamic Client Registration Protocol - RFC 7591 Section 4.1</a>
+ *
+ * @author Daniel DeGroff
+ */
+export enum GrantType {
+  authorization_code = "authorization_code",
+  implicit = "implicit",
+  password = "password",
+  client_credentials = "client_credentials",
+  refresh_token = "refresh_token",
+  unknown = "unknown",
+  device_code = "urn:ietf:params:oauth:grant-type:device_code"
+}
+
+/**
+ * @author Tyler Scott
+ */
+export interface Group {
+  data?: Record<string, any>;
+  id?: UUID;
+  insertInstant?: number;
+  lastUpdateInstant?: number;
+  name?: string;
+  roles?: Record<UUID, Array<ApplicationRole>>;
+  tenantId?: UUID;
+}
+
+/**
+ * Models the Group Created Event.
+ *
+ * @author Daniel DeGroff
+ */
+export interface GroupCreateCompleteEvent extends BaseGroupEvent {
+}
+
+/**
+ * Models the Group Create Event.
+ *
+ * @author Daniel DeGroff
+ */
+export interface GroupCreateEvent extends BaseGroupEvent {
+}
+
+/**
+ * Models the Group Create Complete Event.
+ *
+ * @author Daniel DeGroff
+ */
+export interface GroupDeleteCompleteEvent extends BaseGroupEvent {
+}
+
+/**
+ * Models the Group Delete Event.
+ *
+ * @author Daniel DeGroff
+ */
+export interface GroupDeleteEvent extends BaseGroupEvent {
+}
+
+/**
+ * A User's membership into a Group
+ *
+ * @author Daniel DeGroff
+ */
+export interface GroupMember {
+  data?: Record<string, any>;
+  groupId?: UUID;
+  id?: UUID;
+  insertInstant?: number;
+  user?: User;
+  userId?: UUID;
+}
+
+/**
+ * Models the Group Member Add Complete Event.
+ *
+ * @author Daniel DeGroff
+ */
+export interface GroupMemberAddCompleteEvent extends BaseGroupEvent {
+  members?: Array<GroupMember>;
+}
+
+/**
+ * Models the Group Member Add Event.
+ *
+ * @author Daniel DeGroff
+ */
+export interface GroupMemberAddEvent extends BaseGroupEvent {
+  members?: Array<GroupMember>;
+}
+
+/**
+ * Models the Group Member Remove Complete Event.
+ *
+ * @author Daniel DeGroff
+ */
+export interface GroupMemberRemoveCompleteEvent extends BaseGroupEvent {
+  members?: Array<GroupMember>;
+}
+
+/**
+ * Models the Group Member Remove Event.
+ *
+ * @author Daniel DeGroff
+ */
+export interface GroupMemberRemoveEvent extends BaseGroupEvent {
+  members?: Array<GroupMember>;
+}
+
+/**
+ * Search criteria for Group Members
+ *
+ * @author Daniel DeGroff
+ */
+export interface GroupMemberSearchCriteria extends BaseSearchCriteria {
+  groupId?: UUID;
+  tenantId?: UUID;
+  userId?: UUID;
+}
+
+/**
+ * Search request for Group Members.
+ *
+ * @author Daniel DeGroff
+ */
+export interface GroupMemberSearchRequest {
+  search?: GroupMemberSearchCriteria;
+}
+
+/**
+ * Search response for Group Members
+ *
+ * @author Daniel DeGroff
+ */
+export interface GroupMemberSearchResponse {
+  members?: Array<GroupMember>;
+  total?: number;
+}
+
+/**
+ * Models the Group Member Update Complete Event.
+ *
+ * @author Daniel DeGroff
+ */
+export interface GroupMemberUpdateCompleteEvent extends BaseGroupEvent {
+  members?: Array<GroupMember>;
+}
+
+/**
+ * Models the Group Member Update Event.
+ *
+ * @author Daniel DeGroff
+ */
+export interface GroupMemberUpdateEvent extends BaseGroupEvent {
+  members?: Array<GroupMember>;
+}
+
+/**
+ * Group API request object.
+ *
+ * @author Daniel DeGroff
+ */
+export interface GroupRequest {
+  group?: Group;
+  roleIds?: Array<UUID>;
+}
+
+/**
+ * Group API response object.
+ *
+ * @author Daniel DeGroff
+ */
+export interface GroupResponse {
+  group?: Group;
+  groups?: Array<Group>;
+}
+
+/**
+ * Search criteria for Groups
+ *
+ * @author Daniel DeGroff
+ */
+export interface GroupSearchCriteria extends BaseSearchCriteria {
+  name?: string;
+  tenantId?: UUID;
+}
+
+/**
+ * Search request for Groups.
+ *
+ * @author Daniel DeGroff
+ */
+export interface GroupSearchRequest {
+  search?: GroupSearchCriteria;
+}
+
+/**
+ * Search response for Groups
+ *
+ * @author Daniel DeGroff
+ */
+export interface GroupSearchResponse {
+  groups?: Array<Group>;
+  total?: number;
+}
+
+/**
+ * Models the Group Update Complete Event.
+ *
+ * @author Daniel DeGroff
+ */
+export interface GroupUpdateCompleteEvent extends BaseGroupEvent {
+  original?: Group;
+}
+
+/**
+ * Models the Group Update Event.
+ *
+ * @author Daniel DeGroff
+ */
+export interface GroupUpdateEvent extends BaseGroupEvent {
+  original?: Group;
+}
+
+/**
+ * Type for webhook headers.
+ *
+ * @author Brian Pontarelli
+ */
+export interface HTTPHeaders extends Record<string, string> {
+}
+
+/**
+ * @author Daniel DeGroff
+ */
+export enum HTTPMethod {
+  GET = "GET",
+  POST = "POST",
+  PUT = "PUT",
+  DELETE = "DELETE",
+  HEAD = "HEAD",
+  OPTIONS = "OPTIONS",
+  PATCH = "PATCH"
+}
+
+/**
+ * @author Daniel DeGroff
+ */
+export interface HYPRApplicationConfiguration extends BaseIdentityProviderApplicationConfiguration {
+  relyingPartyApplicationId?: string;
+  relyingPartyURL?: string;
+}
+
+/**
+ * @author Daniel DeGroff
+ */
+export interface HYPRIdentityProvider extends BaseIdentityProvider<HYPRApplicationConfiguration> {
+  relyingPartyApplicationId?: string;
+  relyingPartyURL?: string;
+}
+
+/**
+ * @author Brett Guy
+ */
+export interface IPAccessControlEntry {
+  action?: IPAccessControlEntryAction;
+  endIPAddress?: string;
+  startIPAddress?: string;
+}
+
+/**
+ * @author Brett Guy
+ */
+export enum IPAccessControlEntryAction {
+  Allow = "Allow",
+  Block = "Block"
+}
+
+/**
+ * @author Brett Guy
+ */
+export interface IPAccessControlList {
+  data?: Record<string, any>;
+  entries?: Array<IPAccessControlEntry>;
+  id?: UUID;
+  insertInstant?: number;
+  lastUpdateInstant?: number;
+  name?: string;
+}
+
+/**
+ * @author Brett Guy
+ */
+export interface IPAccessControlListRequest {
+  ipAccessControlList?: IPAccessControlList;
+}
+
+/**
+ * @author Brett Guy
+ */
+export interface IPAccessControlListResponse {
+  ipAccessControlList?: IPAccessControlList;
+  ipAccessControlLists?: Array<IPAccessControlList>;
+}
+
+/**
+ * @author Brett Guy
+ */
+export interface IPAccessControlListSearchCriteria extends BaseSearchCriteria {
+  name?: string;
+}
+
+/**
+ * Search request for IP ACLs .
+ *
+ * @author Brett Guy
+ */
+export interface IPAccessControlListSearchRequest {
+  search?: IPAccessControlListSearchCriteria;
+}
+
+/**
+ * @author Brett Guy
+ */
+export interface IPAccessControlListSearchResponse {
+  ipAccessControlLists?: Array<IPAccessControlList>;
+  total?: number;
+}
+
+/**
+ * @author Daniel DeGroff
+ */
+export interface IdentityProviderLimitUserLinkingPolicy extends Enableable {
+  maximumLinks?: number;
+}
+
+/**
+ * @author Daniel DeGroff
+ */
+export interface IdentityProviderLink {
+  data?: Record<string, any>;
+  displayName?: string;
+  identityProviderId?: UUID;
+  identityProviderName?: string;
+  identityProviderType?: IdentityProviderType;
+  identityProviderUserId?: string;
+  insertInstant?: number;
+  lastLoginInstant?: number;
+  tenantId?: UUID;
+  token?: string;
+  userId?: UUID;
+}
+
+/**
+ * @author Daniel DeGroff
+ */
+export interface IdentityProviderLinkRequest extends BaseEventRequest {
+  identityProviderLink?: IdentityProviderLink;
+  pendingIdPLinkId?: string;
+}
+
+/**
+ * @author Daniel DeGroff
+ */
+export interface IdentityProviderLinkResponse {
+  identityProviderLink?: IdentityProviderLink;
+  identityProviderLinks?: Array<IdentityProviderLink>;
+}
+
+/**
+ * The IdP behavior when no user link has been made yet.
+ *
+ * @author Daniel DeGroff
+ */
+export enum IdentityProviderLinkingStrategy {
+  CreatePendingLink = "CreatePendingLink",
+  Disabled = "Disabled",
+  LinkAnonymously = "LinkAnonymously",
+  LinkByEmail = "LinkByEmail",
+  LinkByEmailForExistingUser = "LinkByEmailForExistingUser",
+  LinkByUsername = "LinkByUsername",
+  LinkByUsernameForExistingUser = "LinkByUsernameForExistingUser",
+  Unsupported = "Unsupported"
+}
+
+/**
+ * @author Brett Pontarelli
+ */
+export enum IdentityProviderLoginMethod {
+  UsePopup = "UsePopup",
+  UseRedirect = "UseRedirect",
+  UseVendorJavaScript = "UseVendorJavaScript"
+}
+
+/**
+ * Login API request object used for login to third-party systems (i.e. Login with Facebook).
+ *
+ * @author Brian Pontarelli
+ */
+export interface IdentityProviderLoginRequest extends BaseLoginRequest {
+  data?: Record<string, string>;
+  encodedJWT?: string;
+  identityProviderId?: UUID;
+  noLink?: boolean;
+}
+
+/**
+ * @author Daniel DeGroff
+ */
+export interface IdentityProviderOauth2Configuration {
+  authorization_endpoint?: string;
+  client_id?: string;
+  client_secret?: string;
+  clientAuthenticationMethod?: ClientAuthenticationMethod;
+  emailClaim?: string;
+  emailVerifiedClaim?: string;
+  issuer?: string;
+  scope?: string;
+  token_endpoint?: string;
+  uniqueIdClaim?: string;
+  userinfo_endpoint?: string;
+  usernameClaim?: string;
+}
+
+export enum ClientAuthenticationMethod {
+  none = "none",
+  client_secret_basic = "client_secret_basic",
+  client_secret_post = "client_secret_post"
+}
+
+/**
+ * @author Daniel DeGroff
+ */
+export interface IdentityProviderPendingLinkResponse {
+  identityProviderTenantConfiguration?: IdentityProviderTenantConfiguration;
+  linkCount?: number;
+  pendingIdPLink?: PendingIdPLink;
+}
+
+/**
+ * @author Daniel DeGroff
+ */
+export interface IdentityProviderRequest {
+  identityProvider?: BaseIdentityProvider<any>;
+}
+
+/**
+ * @author Daniel DeGroff
+ */
+export interface IdentityProviderResponse {
+  identityProvider?: BaseIdentityProvider<any>;
+  identityProviders?: Array<BaseIdentityProvider<any>>;
+}
+
+/**
+ * Search criteria for Identity Providers.
+ *
+ * @author Spencer Witt
+ */
+export interface IdentityProviderSearchCriteria extends BaseSearchCriteria {
+  applicationId?: UUID;
+  name?: string;
+  type?: IdentityProviderType;
+}
+
+/**
+ * Search request for Identity Providers
+ *
+ * @author Spencer Witt
+ */
+export interface IdentityProviderSearchRequest {
+  search?: IdentityProviderSearchCriteria;
+}
+
+/**
+ * Identity Provider response.
+ *
+ * @author Spencer Witt
+ */
+export interface IdentityProviderSearchResponse {
+  identityProviders?: Array<BaseIdentityProvider<any>>;
+  total?: number;
+}
+
+/**
+ * @author Daniel DeGroff
+ */
+export interface IdentityProviderStartLoginRequest extends BaseLoginRequest {
+  data?: Record<string, string>;
+  identityProviderId?: UUID;
+  loginId?: string;
+  state?: Record<string, any>;
+}
+
+/**
+ * @author Daniel DeGroff
+ */
+export interface IdentityProviderStartLoginResponse {
+  code?: string;
+}
+
+/**
+ * @author Daniel DeGroff
+ */
+export interface IdentityProviderTenantConfiguration {
+  data?: Record<string, any>;
+  limitUserLinkCount?: IdentityProviderLimitUserLinkingPolicy;
+}
+
+/**
+ * @author Daniel DeGroff
+ */
+export enum IdentityProviderType {
+  Apple = "Apple",
+  EpicGames = "EpicGames",
+  ExternalJWT = "ExternalJWT",
+  Facebook = "Facebook",
+  Google = "Google",
+  HYPR = "HYPR",
+  LinkedIn = "LinkedIn",
+  Nintendo = "Nintendo",
+  OpenIDConnect = "OpenIDConnect",
+  SAMLv2 = "SAMLv2",
+  SAMLv2IdPInitiated = "SAMLv2IdPInitiated",
+  SonyPSN = "SonyPSN",
+  Steam = "Steam",
+  Twitch = "Twitch",
+  Twitter = "Twitter",
+  Xbox = "Xbox"
+}
+
+/**
+ * Import request.
+ *
+ * @author Brian Pontarelli
+ */
+export interface ImportRequest extends BaseEventRequest {
+  encryptionScheme?: string;
+  factor?: number;
+  users?: Array<User>;
+  validateDbConstraints?: boolean;
+}
+
+/**
+ * A marker interface indicating this event is not scoped to a tenant and will be sent to all webhooks.
+ *
+ * @author Daniel DeGroff
+ */
+export interface InstanceEvent extends NonTransactionalEvent {
+}
+
+/**
+ * The Integration Request
+ *
+ * @author Daniel DeGroff
+ */
+export interface IntegrationRequest {
+  integrations?: Integrations;
+}
+
+/**
+ * The Integration Response
+ *
+ * @author Daniel DeGroff
+ */
+export interface IntegrationResponse {
+  integrations?: Integrations;
+}
+
+/**
+ * Available Integrations
+ *
+ * @author Daniel DeGroff
+ */
+export interface Integrations {
+  cleanspeak?: CleanSpeakConfiguration;
+  kafka?: KafkaConfiguration;
+}
+
+/**
+ * @author Daniel DeGroff
+ */
+export interface IntrospectResponse extends Record<string, any> {
+}
+
+/**
+ * @author Daniel DeGroff
+ */
+export interface IssueResponse {
+  refreshToken?: string;
+  token?: string;
+}
+
+/**
+ * A JSON Web Key as defined by <a href="https://tools.ietf.org/html/rfc7517#section-4">RFC 7517 JSON Web Key (JWK)
+ * Section 4</a> and <a href="https://tools.ietf.org/html/rfc7518">RFC 7518 JSON Web Algorithms (JWA)</a>.
+ *
+ * @author Daniel DeGroff
+ */
+export interface JSONWebKey {
+  alg?: Algorithm;
+  crv?: string;
+  d?: string;
+  dp?: string;
+  dq?: string;
+  e?: string;
+  kid?: string;
+  kty?: KeyType;
+  n?: string;
+  [other: string]: any; // Any other fields
+  p?: string;
+  q?: string;
+  qi?: string;
+  use?: string;
+  x?: string;
+  x5c?: Array<string>;
+  x5t?: string;
+  x5t_S256?: string;
+  y?: string;
+}
+
+/**
+ * Interface for any object that can provide JSON Web key Information.
+ */
+export interface JSONWebKeyInfoProvider {
+}
+
+/**
+ * @author Daniel DeGroff
+ */
+export interface JWKSResponse {
+  keys?: Array<JSONWebKey>;
+}
+
+/**
+ * JSON Web Token (JWT) as defined by RFC 7519.
+ * <pre>
+ * From RFC 7519 Section 1. Introduction:
+ *    The suggested pronunciation of JWT is the same as the English word "jot".
+ * </pre>
+ * The JWT is not Thread-Safe and should not be re-used.
+ *
+ * @author Daniel DeGroff
+ */
+export interface JWT {
+  aud?: any;
+  exp?: number;
+  iat?: number;
+  iss?: string;
+  jti?: string;
+  nbf?: number;
+  [otherClaims: string]: any; // Any other fields
+  sub?: string;
+}
+
+/**
+ * JWT Configuration. A JWT Configuration for an Application may not be active if it is using the global configuration, the configuration
+ * may be <code>enabled = false</code>.
+ *
+ * @author Daniel DeGroff
+ */
+export interface JWTConfiguration extends Enableable {
+  accessTokenKeyId?: UUID;
+  idTokenKeyId?: UUID;
+  refreshTokenExpirationPolicy?: RefreshTokenExpirationPolicy;
+  refreshTokenOneTimeUseConfiguration?: RefreshTokenOneTimeUseConfiguration;
+  refreshTokenRevocationPolicy?: RefreshTokenRevocationPolicy;
+  refreshTokenSlidingWindowConfiguration?: RefreshTokenSlidingWindowConfiguration;
+  refreshTokenTimeToLiveInMinutes?: number;
+  refreshTokenUsagePolicy?: RefreshTokenUsagePolicy;
+  timeToLiveInSeconds?: number;
+}
+
+/**
+ * Models the JWT public key Refresh Token Revoke Event. This event might be for a single
+ * token, a user or an entire application.
+ *
+ * @author Brian Pontarelli
+ */
+export interface JWTPublicKeyUpdateEvent extends BaseEvent {
+  applicationIds?: Array<UUID>;
+}
+
+/**
+ * Models the JWT Refresh Event. This event will be fired when a JWT is "refreshed" (generated) using a Refresh Token.
+ *
+ * @author Daniel DeGroff
+ */
+export interface JWTRefreshEvent extends BaseEvent {
+  applicationId?: UUID;
+  original?: string;
+  refreshToken?: string;
+  token?: string;
+  userId?: UUID;
+}
+
+/**
+ * API response for refreshing a JWT with a Refresh Token.
+ * <p>
+ * Using a different response object from RefreshTokenResponse because the retrieve response will return an object for refreshToken, and this is a
+ * string.
+ *
+ * @author Daniel DeGroff
+ */
+export interface JWTRefreshResponse {
+  refreshToken?: string;
+  refreshTokenId?: UUID;
+  token?: string;
+}
+
+/**
+ * Models the Refresh Token Revoke Event. This event might be for a single token, a user
+ * or an entire application.
+ *
+ * @author Brian Pontarelli
+ */
+export interface JWTRefreshTokenRevokeEvent extends BaseEvent {
+  applicationId?: UUID;
+  applicationTimeToLiveInSeconds?: Record<UUID, number>;
+  refreshToken?: RefreshToken;
+  user?: User;
+  userId?: UUID;
+}
+
+/**
+ * @author Daniel DeGroff
+ */
+export interface JWTVendRequest {
+  claims?: Record<string, any>;
+  keyId?: UUID;
+  timeToLiveInSeconds?: number;
+}
+
+/**
+ * @author Daniel DeGroff
+ */
+export interface JWTVendResponse {
+  token?: string;
+}
+
+/**
+ * @author Daniel DeGroff
+ */
+export interface KafkaConfiguration extends Enableable {
+  defaultTopic?: string;
+  producer?: Record<string, string>;
+}
+
+/**
+ * @author Brett Guy
+ */
+export interface KafkaMessengerConfiguration extends BaseMessengerConfiguration {
+  defaultTopic?: string;
+  producer?: Record<string, string>;
+}
+
+/**
+ * Domain for a public key, key pair or an HMAC secret. This is used by KeyMaster to manage keys for JWTs, SAML, etc.
+ *
+ * @author Brian Pontarelli
+ */
+export interface Key {
+  algorithm?: KeyAlgorithm;
+  certificate?: string;
+  certificateInformation?: CertificateInformation;
+  expirationInstant?: number;
+  hasPrivateKey?: boolean;
+  id?: UUID;
+  insertInstant?: number;
+  issuer?: string;
+  kid?: string;
+  lastUpdateInstant?: number;
+  length?: number;
+  name?: string;
+  privateKey?: string;
+  publicKey?: string;
+  secret?: string;
+  type?: KeyType;
+}
+
+export interface CertificateInformation {
+  issuer?: string;
+  md5Fingerprint?: string;
+  serialNumber?: string;
+  sha1Fingerprint?: string;
+  sha1Thumbprint?: string;
+  sha256Fingerprint?: string;
+  sha256Thumbprint?: string;
+  subject?: string;
+  validFrom?: number;
+  validTo?: number;
+}
+
+export enum KeyAlgorithm {
+  ES256 = "ES256",
+  ES384 = "ES384",
+  ES512 = "ES512",
+  HS256 = "HS256",
+  HS384 = "HS384",
+  HS512 = "HS512",
+  RS256 = "RS256",
+  RS384 = "RS384",
+  RS512 = "RS512"
+}
+
+export enum KeyType {
+  EC = "EC",
+  RSA = "RSA",
+  HMAC = "HMAC"
+}
+
+/**
+ * Key API request object.
+ *
+ * @author Daniel DeGroff
+ */
+export interface KeyRequest {
+  key?: Key;
+}
+
+/**
+ * Key API response object.
+ *
+ * @author Daniel DeGroff
+ */
+export interface KeyResponse {
+  key?: Key;
+  keys?: Array<Key>;
+}
+
+/**
+ * Search criteria for Keys
+ *
+ * @author Spencer Witt
+ */
+export interface KeySearchCriteria extends BaseSearchCriteria {
+  algorithm?: KeyAlgorithm;
+  name?: string;
+  type?: KeyType;
+}
+
+/**
+ * Search request for Keys
+ *
+ * @author Spencer Witt
+ */
+export interface KeySearchRequest {
+  search?: KeySearchCriteria;
+}
+
+/**
+ * Key search response
+ *
+ * @author Spencer Witt
+ */
+export interface KeySearchResponse {
+  keys?: Array<Key>;
+  total?: number;
+}
+
+/**
+ * The use type of a key.
+ *
+ * @author Daniel DeGroff
+ */
+export enum KeyUse {
+  SignOnly = "SignOnly",
+  SignAndVerify = "SignAndVerify",
+  VerifyOnly = "VerifyOnly"
+}
+
+/**
+ * Event to indicate kickstart has been successfully completed.
+ *
+ * @author Daniel DeGroff
+ */
+export interface KickstartSuccessEvent extends BaseEvent {
+  instanceId?: UUID;
+}
+
+/**
+ * Models an LDAP connector.
+ *
+ * @author Trevor Smith
+ */
+export interface LDAPConnectorConfiguration extends BaseConnectorConfiguration {
+  authenticationURL?: string;
+  baseStructure?: string;
+  connectTimeout?: number;
+  identifyingAttribute?: string;
+  lambdaConfiguration?: LambdaConfiguration;
+  loginIdAttribute?: string;
+  readTimeout?: number;
+  requestedAttributes?: Array<string>;
+  securityMethod?: LDAPSecurityMethod;
+  systemAccountDN?: string;
+  systemAccountPassword?: string;
+}
+
+export enum LDAPSecurityMethod {
+  None = "None",
+  LDAPS = "LDAPS",
+  StartTLS = "StartTLS"
+}
+
+export interface LambdaConfiguration {
+  reconcileId?: UUID;
+}
+
+/**
+ * A JavaScript lambda function that is executed during certain events inside FusionAuth.
+ *
+ * @author Brian Pontarelli
+ */
+export interface Lambda {
+  body?: string;
+  debug?: boolean;
+  engineType?: LambdaEngineType;
+  id?: UUID;
+  insertInstant?: number;
+  lastUpdateInstant?: number;
+  name?: string;
+  type?: LambdaType;
+}
+
+/**
+ * @author Daniel DeGroff
+ */
+export enum LambdaEngineType {
+  GraalJS = "GraalJS",
+  Nashorn = "Nashorn"
+}
+
+/**
+ * Lambda API request object.
+ *
+ * @author Brian Pontarelli
+ */
+export interface LambdaRequest {
+  lambda?: Lambda;
+}
+
+/**
+ * Lambda API response object.
+ *
+ * @author Brian Pontarelli
+ */
+export interface LambdaResponse {
+  lambda?: Lambda;
+  lambdas?: Array<Lambda>;
+}
+
+/**
+ * Search criteria for Lambdas
+ *
+ * @author Mark Manes
+ */
+export interface LambdaSearchCriteria extends BaseSearchCriteria {
+  body?: string;
+  name?: string;
+  type?: LambdaType;
+}
+
+/**
+ * Search request for Lambdas
+ *
+ * @author Mark Manes
+ */
+export interface LambdaSearchRequest {
+  search?: LambdaSearchCriteria;
+}
+
+/**
+ * Lambda search response
+ *
+ * @author Mark Manes
+ */
+export interface LambdaSearchResponse {
+  lambdas?: Array<Lambda>;
+  total?: number;
+}
+
+/**
+ * The types of lambdas that indicate how they are invoked by FusionAuth.
+ *
+ * @author Brian Pontarelli
+ */
+export enum LambdaType {
+  JWTPopulate = "JWTPopulate",
+  OpenIDReconcile = "OpenIDReconcile",
+  SAMLv2Reconcile = "SAMLv2Reconcile",
+  SAMLv2Populate = "SAMLv2Populate",
+  AppleReconcile = "AppleReconcile",
+  ExternalJWTReconcile = "ExternalJWTReconcile",
+  FacebookReconcile = "FacebookReconcile",
+  GoogleReconcile = "GoogleReconcile",
+  HYPRReconcile = "HYPRReconcile",
+  TwitterReconcile = "TwitterReconcile",
+  LDAPConnectorReconcile = "LDAPConnectorReconcile",
+  LinkedInReconcile = "LinkedInReconcile",
+  EpicGamesReconcile = "EpicGamesReconcile",
+  NintendoReconcile = "NintendoReconcile",
+  SonyPSNReconcile = "SonyPSNReconcile",
+  SteamReconcile = "SteamReconcile",
+  TwitchReconcile = "TwitchReconcile",
+  XboxReconcile = "XboxReconcile",
+  ClientCredentialsJWTPopulate = "ClientCredentialsJWTPopulate",
+  SCIMServerGroupRequestConverter = "SCIMServerGroupRequestConverter",
+  SCIMServerGroupResponseConverter = "SCIMServerGroupResponseConverter",
+  SCIMServerUserRequestConverter = "SCIMServerUserRequestConverter",
+  SCIMServerUserResponseConverter = "SCIMServerUserResponseConverter",
+  SelfServiceRegistrationValidation = "SelfServiceRegistrationValidation",
+  UserInfoPopulate = "UserInfoPopulate",
+  LoginValidation = "LoginValidation"
+}
+
+/**
+ * @author Daniel DeGroff
+ */
+export interface LinkedInApplicationConfiguration extends BaseIdentityProviderApplicationConfiguration {
+  buttonText?: string;
+  client_id?: string;
+  client_secret?: string;
+  scope?: string;
+}
+
+/**
+ * @author Daniel DeGroff
+ */
+export interface LinkedInIdentityProvider extends BaseIdentityProvider<LinkedInApplicationConfiguration> {
+  buttonText?: string;
+  client_id?: string;
+  client_secret?: string;
+  scope?: string;
+}
+
+/**
+ * Models a set of localized Integers that can be stored as JSON.
+ *
+ * @author Daniel DeGroff
+ */
+export interface LocalizedIntegers extends Record<string, number> {
+}
+
+/**
+ * Models a set of localized Strings that can be stored as JSON.
+ *
+ * @author Brian Pontarelli
+ */
+export interface LocalizedStrings extends Record<string, string> {
+}
+
+/**
+ * Location information. Useful for IP addresses and other displayable data objects.
+ *
+ * @author Brian Pontarelli
+ */
+export interface Location {
+  city?: string;
+  country?: string;
+  displayString?: string;
+  latitude?: number;
+  longitude?: number;
+  region?: string;
+  zipcode?: string;
+}
+
+/**
+ * A historical state of a user log event. Since events can be modified, this stores the historical state.
+ *
+ * @author Brian Pontarelli
+ */
+export interface LogHistory {
+  historyItems?: Array<HistoryItem>;
+}
+
+export interface HistoryItem {
+  actionerUserId?: UUID;
+  comment?: string;
+  createInstant?: number;
+  expiry?: number;
+}
+
+/**
+ * @author Daniel DeGroff
+ */
+export interface LoginHintConfiguration extends Enableable {
+  parameterName?: string;
+}
+
+/**
+ * Login Ping API request object.
+ *
+ * @author Daniel DeGroff
+ */
+export interface LoginPingRequest extends BaseLoginRequest {
+  userId?: UUID;
+}
+
+/**
+ * The summary of the action that is preventing login to be returned on the login response.
+ *
+ * @author Daniel DeGroff
+ */
+export interface LoginPreventedResponse {
+  actionerUserId?: UUID;
+  actionId?: UUID;
+  expiry?: number;
+  localizedName?: string;
+  localizedOption?: string;
+  localizedReason?: string;
+  name?: string;
+  option?: string;
+  reason?: string;
+  reasonCode?: string;
+}
+
+/**
+ * @author Daniel DeGroff
+ */
+export interface LoginRecordExportRequest extends BaseExportRequest {
+  criteria?: LoginRecordSearchCriteria;
+}
+
+/**
+ * @author Daniel DeGroff
+ */
+export interface LoginRecordSearchCriteria extends BaseSearchCriteria {
+  applicationId?: UUID;
+  end?: number;
+  start?: number;
+  userId?: UUID;
+}
+
+/**
+ * @author Daniel DeGroff
+ */
+export interface LoginRecordSearchRequest {
+  retrieveTotal?: boolean;
+  search?: LoginRecordSearchCriteria;
+}
+
+/**
+ * A raw login record response
+ *
+ * @author Daniel DeGroff
+ */
+export interface LoginRecordSearchResponse {
+  logins?: Array<DisplayableRawLogin>;
+  total?: number;
+}
+
+/**
+ * Response for the login report.
+ *
+ * @author Brian Pontarelli
+ */
+export interface LoginReportResponse {
+  hourlyCounts?: Array<Count>;
+  total?: number;
+}
+
+/**
+ * Login API request object.
+ *
+ * @author Seth Musselman
+ */
+export interface LoginRequest extends BaseLoginRequest {
+  loginId?: string;
+  oneTimePassword?: string;
+  password?: string;
+  twoFactorTrustId?: string;
+}
+
+/**
+ * @author Brian Pontarelli
+ */
+export interface LoginResponse {
+  actions?: Array<LoginPreventedResponse>;
+  changePasswordId?: string;
+  changePasswordReason?: ChangePasswordReason;
+  configurableMethods?: Array<string>;
+  emailVerificationId?: string;
+  methods?: Array<TwoFactorMethod>;
+  pendingIdPLinkId?: string;
+  refreshToken?: string;
+  refreshTokenId?: UUID;
+  registrationVerificationId?: string;
+  state?: Record<string, any>;
+  threatsDetected?: Array<AuthenticationThreats>;
+  token?: string;
+  tokenExpirationInstant?: number;
+  trustToken?: string;
+  twoFactorId?: string;
+  twoFactorTrustId?: string;
+  user?: User;
+}
+
+/**
+ * @author Matthew Altman
+ */
+export enum LogoutBehavior {
+  RedirectOnly = "RedirectOnly",
+  AllApplications = "AllApplications"
+}
+
+/**
+ * Request for the Logout API that can be used as an alternative to URL parameters.
+ *
+ * @author Brian Pontarelli
+ */
+export interface LogoutRequest extends BaseEventRequest {
+  global?: boolean;
+  refreshToken?: string;
+}
+
+/**
+ * @author Daniel DeGroff
+ */
+export interface LookupResponse {
+  identityProvider?: IdentityProviderDetails;
+}
+
+export interface IdentityProviderDetails {
+  applicationIds?: Array<UUID>;
+  id?: UUID;
+  idpEndpoint?: string;
+  name?: string;
+  oauth2?: IdentityProviderOauth2Configuration;
+  type?: IdentityProviderType;
+}
+
+/**
+ * This class contains the managed fields that are also put into the database during FusionAuth setup.
+ * <p>
+ * Internal Note: These fields are also declared in SQL in order to bootstrap the system. These need to stay in sync.
+ * Any changes to these fields needs to also be reflected in mysql.sql and postgresql.sql
+ *
+ * @author Brian Pontarelli
+ */
+export interface ManagedFields {
+}
+
+/**
+ * @author Daniel DeGroff
+ */
+export interface MaximumPasswordAge extends Enableable {
+  days?: number;
+}
+
+/**
+ * Group Member Delete Request
+ *
+ * @author Daniel DeGroff
+ */
+export interface MemberDeleteRequest {
+  memberIds?: Array<UUID>;
+  members?: Record<UUID, Array<UUID>>;
+}
+
+/**
+ * Group Member Request
+ *
+ * @author Daniel DeGroff
+ */
+export interface MemberRequest {
+  members?: Record<UUID, Array<GroupMember>>;
+}
+
+/**
+ * Group Member Response
+ *
+ * @author Daniel DeGroff
+ */
+export interface MemberResponse {
+  members?: Record<UUID, Array<GroupMember>>;
+}
+
+/**
+ * @author Mikey Sleevi
+ */
+export interface Message {
+}
+
+/**
+ * Stores an message template used to distribute messages;
+ *
+ * @author Michael Sleevi
+ */
+export interface MessageTemplate {
+  data?: Record<string, any>;
+  id?: UUID;
+  insertInstant?: number;
+  lastUpdateInstant?: number;
+  name?: string;
+  type?: MessageType;
+}
+
+/**
+ * A Message Template Request to the API
+ *
+ * @author Michael Sleevi
+ */
+export interface MessageTemplateRequest {
+  messageTemplate?: MessageTemplate;
+}
+
+/**
+ * @author Michael Sleevi
+ */
+export interface MessageTemplateResponse {
+  messageTemplate?: MessageTemplate;
+  messageTemplates?: Array<MessageTemplate>;
+}
+
+/**
+ * @author Mikey Sleevi
+ */
+export enum MessageType {
+  SMS = "SMS"
+}
+
+/**
+ * @author Brett Guy
+ */
+export interface MessengerRequest {
+  messenger?: BaseMessengerConfiguration;
+}
+
+/**
+ * @author Brett Guy
+ */
+export interface MessengerResponse {
+  messenger?: BaseMessengerConfiguration;
+  messengers?: Array<BaseMessengerConfiguration>;
+}
+
+/**
+ * @author Daniel DeGroff
+ */
+export interface MessengerTransport {
+}
+
+/**
+ * @author Brett Guy
+ */
+export enum MessengerType {
+  Generic = "Generic",
+  Kafka = "Kafka",
+  Twilio = "Twilio"
+}
+
+/**
+ * @author Daniel DeGroff
+ */
+export interface MinimumPasswordAge extends Enableable {
+  seconds?: number;
+}
+
+/**
+ * Response for the daily active user report.
+ *
+ * @author Brian Pontarelli
+ */
+export interface MonthlyActiveUserReportResponse {
+  monthlyActiveUsers?: Array<Count>;
+  total?: number;
+}
+
+/**
+ * @author Daniel DeGroff
+ */
+export enum MultiFactorLoginPolicy {
+  Disabled = "Disabled",
+  Enabled = "Enabled",
+  Required = "Required"
+}
+
+/**
+ * @author Brett Pontarelli
+ */
+export interface NintendoApplicationConfiguration extends BaseIdentityProviderApplicationConfiguration {
+  buttonText?: string;
+  client_id?: string;
+  client_secret?: string;
+  emailClaim?: string;
+  scope?: string;
+  uniqueIdClaim?: string;
+  usernameClaim?: string;
+}
+
+/**
+ * Nintendo gaming login provider.
+ *
+ * @author Brett Pontarelli
+ */
+export interface NintendoIdentityProvider extends BaseIdentityProvider<NintendoApplicationConfiguration> {
+  buttonText?: string;
+  client_id?: string;
+  client_secret?: string;
+  emailClaim?: string;
+  scope?: string;
+  uniqueIdClaim?: string;
+  usernameClaim?: string;
+}
+
+/**
+ * A marker interface indicating this event cannot be made transactional.
+ *
+ * @author Daniel DeGroff
+ */
+export interface NonTransactionalEvent {
+}
+
+/**
+ * @author Daniel DeGroff
+ */
+export interface OAuth2Configuration {
+  authorizedOriginURLs?: Array<string>;
+  authorizedRedirectURLs?: Array<string>;
+  authorizedURLValidationPolicy?: Oauth2AuthorizedURLValidationPolicy;
+  clientAuthenticationPolicy?: ClientAuthenticationPolicy;
+  clientId?: string;
+  clientSecret?: string;
+  consentMode?: OAuthScopeConsentMode;
+  debug?: boolean;
+  deviceVerificationURL?: string;
+  enabledGrants?: Array<GrantType>;
+  generateRefreshTokens?: boolean;
+  logoutBehavior?: LogoutBehavior;
+  logoutURL?: string;
+  proofKeyForCodeExchangePolicy?: ProofKeyForCodeExchangePolicy;
+  providedScopePolicy?: ProvidedScopePolicy;
+  relationship?: OAuthApplicationRelationship;
+  requireClientAuthentication?: boolean;
+  requireRegistration?: boolean;
+  scopeHandlingPolicy?: OAuthScopeHandlingPolicy;
+  unknownScopePolicy?: UnknownScopePolicy;
+}
+
+/**
+ * The application's relationship to the authorization server. First-party applications will be granted implicit permission for requested scopes.
+ * Third-party applications will use the {@link OAuthScopeConsentMode} policy.
+ *
+ * @author Spencer Witt
+ */
+export enum OAuthApplicationRelationship {
+  FirstParty = "FirstParty",
+  ThirdParty = "ThirdParty"
+}
+
+/**
+ * @author Daniel DeGroff
+ */
+export interface OAuthConfigurationResponse {
+  httpSessionMaxInactiveInterval?: number;
+  logoutURL?: string;
+  oauthConfiguration?: OAuth2Configuration;
+}
+
+/**
+ * @author Daniel DeGroff
+ */
+export interface OAuthError {
+  change_password_id?: string;
+  error?: OAuthErrorType;
+  error_description?: string;
+  error_reason?: OAuthErrorReason;
+  error_uri?: string;
+  two_factor_id?: string;
+  two_factor_methods?: Array<TwoFactorMethod>;
+}
+
+export enum OAuthErrorReason {
+  auth_code_not_found = "auth_code_not_found",
+  access_token_malformed = "access_token_malformed",
+  access_token_expired = "access_token_expired",
+  access_token_unavailable_for_processing = "access_token_unavailable_for_processing",
+  access_token_failed_processing = "access_token_failed_processing",
+  access_token_invalid = "access_token_invalid",
+  access_token_required = "access_token_required",
+  refresh_token_not_found = "refresh_token_not_found",
+  refresh_token_type_not_supported = "refresh_token_type_not_supported",
+  invalid_client_id = "invalid_client_id",
+  invalid_user_credentials = "invalid_user_credentials",
+  invalid_grant_type = "invalid_grant_type",
+  invalid_origin = "invalid_origin",
+  invalid_origin_opaque = "invalid_origin_opaque",
+  invalid_pkce_code_verifier = "invalid_pkce_code_verifier",
+  invalid_pkce_code_challenge = "invalid_pkce_code_challenge",
+  invalid_pkce_code_challenge_method = "invalid_pkce_code_challenge_method",
+  invalid_redirect_uri = "invalid_redirect_uri",
+  invalid_response_mode = "invalid_response_mode",
+  invalid_response_type = "invalid_response_type",
+  invalid_id_token_hint = "invalid_id_token_hint",
+  invalid_post_logout_redirect_uri = "invalid_post_logout_redirect_uri",
+  invalid_device_code = "invalid_device_code",
+  invalid_user_code = "invalid_user_code",
+  invalid_additional_client_id = "invalid_additional_client_id",
+  invalid_target_entity_scope = "invalid_target_entity_scope",
+  invalid_entity_permission_scope = "invalid_entity_permission_scope",
+  invalid_user_id = "invalid_user_id",
+  grant_type_disabled = "grant_type_disabled",
+  missing_client_id = "missing_client_id",
+  missing_client_secret = "missing_client_secret",
+  missing_code = "missing_code",
+  missing_code_challenge = "missing_code_challenge",
+  missing_code_verifier = "missing_code_verifier",
+  missing_device_code = "missing_device_code",
+  missing_grant_type = "missing_grant_type",
+  missing_redirect_uri = "missing_redirect_uri",
+  missing_refresh_token = "missing_refresh_token",
+  missing_response_type = "missing_response_type",
+  missing_token = "missing_token",
+  missing_user_code = "missing_user_code",
+  missing_user_id = "missing_user_id",
+  missing_verification_uri = "missing_verification_uri",
+  login_prevented = "login_prevented",
+  not_licensed = "not_licensed",
+  user_code_expired = "user_code_expired",
+  user_expired = "user_expired",
+  user_locked = "user_locked",
+  user_not_found = "user_not_found",
+  client_authentication_missing = "client_authentication_missing",
+  invalid_client_authentication_scheme = "invalid_client_authentication_scheme",
+  invalid_client_authentication = "invalid_client_authentication",
+  client_id_mismatch = "client_id_mismatch",
+  change_password_administrative = "change_password_administrative",
+  change_password_breached = "change_password_breached",
+  change_password_expired = "change_password_expired",
+  change_password_validation = "change_password_validation",
+  unknown = "unknown",
+  missing_required_scope = "missing_required_scope",
+  unknown_scope = "unknown_scope",
+  consent_canceled = "consent_canceled"
+}
+
+export enum OAuthErrorType {
+  invalid_request = "invalid_request",
+  invalid_client = "invalid_client",
+  invalid_grant = "invalid_grant",
+  invalid_token = "invalid_token",
+  unauthorized_client = "unauthorized_client",
+  invalid_scope = "invalid_scope",
+  server_error = "server_error",
+  unsupported_grant_type = "unsupported_grant_type",
+  unsupported_response_type = "unsupported_response_type",
+  access_denied = "access_denied",
+  change_password_required = "change_password_required",
+  not_licensed = "not_licensed",
+  two_factor_required = "two_factor_required",
+  authorization_pending = "authorization_pending",
+  expired_token = "expired_token",
+  unsupported_token_type = "unsupported_token_type"
+}
+
+/**
+ * @author Daniel DeGroff
+ */
+export interface OAuthResponse {
+}
+
+/**
+ * Controls the policy for requesting user permission to grant access to requested scopes during an OAuth workflow
+ * for a third-party application.
+ *
+ * @author Spencer Witt
+ */
+export enum OAuthScopeConsentMode {
+  AlwaysPrompt = "AlwaysPrompt",
+  RememberDecision = "RememberDecision",
+  NeverPrompt = "NeverPrompt"
+}
+
+/**
+ * Controls the policy for whether OAuth workflows will more strictly adhere to the OAuth and OIDC specification
+ * or run in backwards compatibility mode.
+ *
+ * @author David Charles
+ */
+export enum OAuthScopeHandlingPolicy {
+  Compatibility = "Compatibility",
+  Strict = "Strict"
+}
+
+/**
+ * @author Johnathon Wood
+ */
+export enum Oauth2AuthorizedURLValidationPolicy {
+  AllowWildcards = "AllowWildcards",
+  ExactMatch = "ExactMatch"
+}
+
+/**
+ * A marker interface indicating this event is an event that can supply a linked object Id.
+ *
+ * @author Spencer Witt
+ */
+export interface ObjectIdentifiable {
+}
+
+/**
+ * @author Daniel DeGroff
+ */
+export enum ObjectState {
+  Active = "Active",
+  Inactive = "Inactive",
+  PendingDelete = "PendingDelete"
+}
+
+/**
+ * OpenID Connect Configuration as described by the <a href="https://openid.net/specs/openid-connect-discovery-1_0.html#ProviderMetadata">OpenID
+ * Provider Metadata</a>.
+ *
+ * @author Daniel DeGroff
+ */
+export interface OpenIdConfiguration {
+  authorization_endpoint?: string;
+  backchannel_logout_supported?: boolean;
+  claims_supported?: Array<string>;
+  device_authorization_endpoint?: string;
+  end_session_endpoint?: string;
+  frontchannel_logout_supported?: boolean;
+  grant_types_supported?: Array<string>;
+  id_token_signing_alg_values_supported?: Array<string>;
+  issuer?: string;
+  jwks_uri?: string;
+  response_modes_supported?: Array<string>;
+  response_types_supported?: Array<string>;
+  scopes_supported?: Array<string>;
+  subject_types_supported?: Array<string>;
+  token_endpoint?: string;
+  token_endpoint_auth_methods_supported?: Array<string>;
+  userinfo_endpoint?: string;
+  userinfo_signing_alg_values_supported?: Array<string>;
+}
+
+/**
+ * @author Daniel DeGroff
+ */
+export interface OpenIdConnectApplicationConfiguration extends BaseIdentityProviderApplicationConfiguration {
+  buttonImageURL?: string;
+  buttonText?: string;
+  oauth2?: IdentityProviderOauth2Configuration;
+}
+
+/**
+ * @author Daniel DeGroff
+ */
+export interface OpenIdConnectIdentityProvider extends BaseIdentityProvider<OpenIdConnectApplicationConfiguration> {
+  buttonImageURL?: string;
+  buttonText?: string;
+  domains?: Array<string>;
+  oauth2?: IdentityProviderOauth2Configuration;
+  postRequest?: boolean;
+}
+
+/**
+ * @author Daniel DeGroff
+ */
+export interface PasswordBreachDetection extends Enableable {
+  matchMode?: BreachMatchMode;
+  notifyUserEmailTemplateId?: UUID;
+  onLogin?: BreachAction;
+}
+
+export enum BreachAction {
+  Off = "Off",
+  RecordOnly = "RecordOnly",
+  NotifyUser = "NotifyUser",
+  RequireChange = "RequireChange"
+}
+
+export enum BreachMatchMode {
+  Low = "Low",
+  Medium = "Medium",
+  High = "High"
+}
+
+/**
+ * Password Encryption Scheme Configuration
+ *
+ * @author Daniel DeGroff
+ */
+export interface PasswordEncryptionConfiguration {
+  encryptionScheme?: string;
+  encryptionSchemeFactor?: number;
+  modifyEncryptionSchemeOnLogin?: boolean;
+}
+
+/**
+ * @author Derek Klatt
+ */
+export interface PasswordValidationRules {
+  breachDetection?: PasswordBreachDetection;
+  maxLength?: number;
+  minLength?: number;
+  rememberPreviousPasswords?: RememberPreviousPasswords;
+  requireMixedCase?: boolean;
+  requireNonAlpha?: boolean;
+  requireNumber?: boolean;
+  validateOnLogin?: boolean;
+}
+
+/**
+ * @author Daniel DeGroff
+ */
+export interface PasswordValidationRulesResponse {
+  passwordValidationRules?: PasswordValidationRules;
+}
+
+/**
+ * Interface for all identity providers that are passwordless and do not accept a password.
+ */
+export interface PasswordlessIdentityProvider {
+}
+
+/**
+ * @author Daniel DeGroff
+ */
+export interface PasswordlessLoginRequest extends BaseLoginRequest {
+  code?: string;
+  twoFactorTrustId?: string;
+}
+
+/**
+ * @author Daniel DeGroff
+ */
+export interface PasswordlessSendRequest {
+  applicationId?: UUID;
+  code?: string;
+  loginId?: string;
+  state?: Record<string, any>;
+}
+
+/**
+ * @author Daniel DeGroff
+ */
+export interface PasswordlessStartRequest {
+  applicationId?: UUID;
+  loginId?: string;
+  state?: Record<string, any>;
+}
+
+/**
+ * @author Daniel DeGroff
+ */
+export interface PasswordlessStartResponse {
+  code?: string;
+}
+
+/**
+ * @author Daniel DeGroff
+ */
+export interface PendingIdPLink {
+  displayName?: string;
+  email?: string;
+  identityProviderId?: UUID;
+  identityProviderLinks?: Array<IdentityProviderLink>;
+  identityProviderName?: string;
+  identityProviderTenantConfiguration?: IdentityProviderTenantConfiguration;
+  identityProviderType?: IdentityProviderType;
+  identityProviderUserId?: string;
+  user?: User;
+  username?: string;
+}
+
+/**
+ * @author Brian Pontarelli
+ */
+export interface PendingResponse {
+  users?: Array<User>;
+}
+
+/**
+ * @author Michael Sleevi
+ */
+export interface PreviewMessageTemplateRequest {
+  locale?: string;
+  messageTemplate?: MessageTemplate;
+}
+
+/**
+ * @author Michael Sleevi
+ */
+export interface PreviewMessageTemplateResponse {
+  errors?: Errors;
+  message?: SMSMessage;
+}
+
+/**
+ * @author Brian Pontarelli
+ */
+export interface PreviewRequest {
+  emailTemplate?: EmailTemplate;
+  locale?: string;
+}
+
+/**
+ * @author Seth Musselman
+ */
+export interface PreviewResponse {
+  email?: Email;
+  errors?: Errors;
+}
+
+/**
+ * @author Brett Guy
+ */
+export enum ProofKeyForCodeExchangePolicy {
+  Required = "Required",
+  NotRequired = "NotRequired",
+  NotRequiredWhenUsingClientAuthentication = "NotRequiredWhenUsingClientAuthentication"
+}
+
+/**
+ * The handling policy for scopes provided by FusionAuth
+ *
+ * @author Spencer Witt
+ */
+export interface ProvidedScopePolicy {
+  address?: Requirable;
+  email?: Requirable;
+  phone?: Requirable;
+  profile?: Requirable;
+}
+
 /**
  * Allows the Relying Party to specify desired attributes of a new credential.
  *
@@ -10938,10 +9661,637 @@ export interface PublicKeyCredentialCreationOptions {
 }
 
 /**
+ * Contains attributes for the Relying Party to refer to an existing public key credential as an input parameter.
+ *
+ * @author Spencer Witt
+ */
+export interface PublicKeyCredentialDescriptor {
+  id?: string;
+  transports?: Array<string>;
+  type?: PublicKeyCredentialType;
+}
+
+/**
+ * Describes a user account or WebAuthn Relying Party associated with a public key credential
+ */
+export interface PublicKeyCredentialEntity {
+  name?: string;
+}
+
+/**
+ * Supply information on credential type and algorithm to the <i>authenticator</i>.
+ *
+ * @author Spencer Witt
+ */
+export interface PublicKeyCredentialParameters {
+  alg?: CoseAlgorithmIdentifier;
+  type?: PublicKeyCredentialType;
+}
+
+/**
+ * Supply additional information about the Relying Party when creating a new credential
+ *
+ * @author Spencer Witt
+ */
+export interface PublicKeyCredentialRelyingPartyEntity extends PublicKeyCredentialEntity {
+  id?: string;
+}
+
+/**
+ * Provides the <i>authenticator</i> with the data it needs to generate an assertion.
+ *
+ * @author Spencer Witt
+ */
+export interface PublicKeyCredentialRequestOptions {
+  allowCredentials?: Array<PublicKeyCredentialDescriptor>;
+  challenge?: string;
+  rpId?: string;
+  timeout?: number;
+  userVerification?: UserVerificationRequirement;
+}
+
+/**
+ * Defines valid credential types. This is an extension point in the WebAuthn spec. The only defined value at this time is "public-key"
+ *
+ * @author Spencer Witt
+ */
+export enum PublicKeyCredentialType {
+  publicKey = "public-key"
+}
+
+/**
+ * Supply additional information about the user account when creating a new credential
+ *
+ * @author Spencer Witt
+ */
+export interface PublicKeyCredentialUserEntity extends PublicKeyCredentialEntity {
+  displayName?: string;
+  id?: string;
+}
+
+/**
+ * JWT Public Key Response Object
+ *
  * @author Daniel DeGroff
  */
-export interface JWTVendResponse {
+export interface PublicKeyResponse {
+  publicKey?: string;
+  publicKeys?: Record<string, string>;
+}
+
+/**
+ * @author Daniel DeGroff
+ */
+export interface RateLimitedRequestConfiguration extends Enableable {
+  limit?: number;
+  timePeriodInSeconds?: number;
+}
+
+/**
+ * @author Daniel DeGroff
+ */
+export enum RateLimitedRequestType {
+  FailedLogin = "FailedLogin",
+  ForgotPassword = "ForgotPassword",
+  SendEmailVerification = "SendEmailVerification",
+  SendPasswordless = "SendPasswordless",
+  SendRegistrationVerification = "SendRegistrationVerification",
+  SendTwoFactor = "SendTwoFactor"
+}
+
+/**
+ * Raw login information for each time a user logs into an application.
+ *
+ * @author Brian Pontarelli
+ */
+export interface RawLogin {
+  applicationId?: UUID;
+  instant?: number;
+  ipAddress?: string;
+  userId?: UUID;
+}
+
+/**
+ * @author Brian Pontarelli
+ */
+export enum ReactorFeatureStatus {
+  ACTIVE = "ACTIVE",
+  DISCONNECTED = "DISCONNECTED",
+  PENDING = "PENDING",
+  DISABLED = "DISABLED",
+  UNKNOWN = "UNKNOWN"
+}
+
+/**
+ * @author Daniel DeGroff
+ */
+export interface ReactorMetrics {
+  breachedPasswordMetrics?: Record<UUID, BreachedPasswordTenantMetric>;
+}
+
+/**
+ * @author Daniel DeGroff
+ */
+export interface ReactorMetricsResponse {
+  metrics?: ReactorMetrics;
+}
+
+/**
+ * Request for managing FusionAuth Reactor and licenses.
+ *
+ * @author Brian Pontarelli
+ */
+export interface ReactorRequest {
+  license?: string;
+  licenseId?: string;
+}
+
+/**
+ * @author Daniel DeGroff
+ */
+export interface ReactorResponse {
+  status?: ReactorStatus;
+}
+
+/**
+ * @author Daniel DeGroff
+ */
+export interface ReactorStatus {
+  advancedIdentityProviders?: ReactorFeatureStatus;
+  advancedLambdas?: ReactorFeatureStatus;
+  advancedMultiFactorAuthentication?: ReactorFeatureStatus;
+  advancedOAuthScopes?: ReactorFeatureStatus;
+  advancedOAuthScopesCustomScopes?: ReactorFeatureStatus;
+  advancedOAuthScopesThirdPartyApplications?: ReactorFeatureStatus;
+  advancedRegistration?: ReactorFeatureStatus;
+  applicationMultiFactorAuthentication?: ReactorFeatureStatus;
+  applicationThemes?: ReactorFeatureStatus;
+  breachedPasswordDetection?: ReactorFeatureStatus;
+  connectors?: ReactorFeatureStatus;
+  entityManagement?: ReactorFeatureStatus;
+  expiration?: string;
+  licenseAttributes?: Record<string, string>;
+  licensed?: boolean;
+  scimServer?: ReactorFeatureStatus;
+  threatDetection?: ReactorFeatureStatus;
+  webAuthn?: ReactorFeatureStatus;
+  webAuthnPlatformAuthenticators?: ReactorFeatureStatus;
+  webAuthnRoamingAuthenticators?: ReactorFeatureStatus;
+}
+
+/**
+ * Response for the user login report.
+ *
+ * @author Seth Musselman
+ */
+export interface RecentLoginResponse {
+  logins?: Array<DisplayableRawLogin>;
+}
+
+/**
+ * @author Daniel DeGroff
+ */
+export interface RefreshRequest extends BaseEventRequest {
+  refreshToken?: string;
   token?: string;
+}
+
+/**
+ * @author Daniel DeGroff
+ */
+export interface RefreshResponse {
+}
+
+/**
+ * Models a JWT Refresh Token.
+ *
+ * @author Daniel DeGroff
+ */
+export interface RefreshToken {
+  applicationId?: UUID;
+  data?: Record<string, any>;
+  id?: UUID;
+  insertInstant?: number;
+  metaData?: MetaData;
+  startInstant?: number;
+  tenantId?: UUID;
+  token?: string;
+  userId?: UUID;
+}
+
+export interface MetaData {
+  data?: Record<string, any>;
+  device?: DeviceInfo;
+  scopes?: Array<string>;
+}
+
+/**
+ * @author Daniel DeGroff
+ */
+export enum RefreshTokenExpirationPolicy {
+  Fixed = "Fixed",
+  SlidingWindow = "SlidingWindow",
+  SlidingWindowWithMaximumLifetime = "SlidingWindowWithMaximumLifetime"
+}
+
+/**
+ * Refresh Token Import request.
+ *
+ * @author Brett Guy
+ */
+export interface RefreshTokenImportRequest {
+  refreshTokens?: Array<RefreshToken>;
+  validateDbConstraints?: boolean;
+}
+
+/**
+ * Refresh token one-time use configuration. This configuration is utilized when the usage policy is
+ * configured for one-time use.
+ *
+ * @author Daniel DeGroff
+ */
+export interface RefreshTokenOneTimeUseConfiguration {
+  gracePeriodInSeconds?: number;
+}
+
+/**
+ * API response for retrieving Refresh Tokens
+ *
+ * @author Daniel DeGroff
+ */
+export interface RefreshTokenResponse {
+  refreshToken?: RefreshToken;
+  refreshTokens?: Array<RefreshToken>;
+}
+
+/**
+ * @author Daniel DeGroff
+ */
+export interface RefreshTokenRevocationPolicy {
+  onLoginPrevented?: boolean;
+  onMultiFactorEnable?: boolean;
+  onOneTimeTokenReuse?: boolean;
+  onPasswordChanged?: boolean;
+}
+
+/**
+ * Request for the Refresh Token API to revoke a refresh token rather than using the URL parameters.
+ *
+ * @author Brian Pontarelli
+ */
+export interface RefreshTokenRevokeRequest extends BaseEventRequest {
+  applicationId?: UUID;
+  token?: string;
+  userId?: UUID;
+}
+
+/**
+ * @author Daniel DeGroff
+ */
+export interface RefreshTokenSlidingWindowConfiguration {
+  maximumTimeToLiveInMinutes?: number;
+}
+
+/**
+ * @author Daniel DeGroff
+ */
+export enum RefreshTokenUsagePolicy {
+  Reusable = "Reusable",
+  OneTimeUse = "OneTimeUse"
+}
+
+/**
+ * Registration delete API request object.
+ *
+ * @author Brian Pontarelli
+ */
+export interface RegistrationDeleteRequest extends BaseEventRequest {
+}
+
+/**
+ * Response for the registration report.
+ *
+ * @author Brian Pontarelli
+ */
+export interface RegistrationReportResponse {
+  hourlyCounts?: Array<Count>;
+  total?: number;
+}
+
+/**
+ * Registration API request object.
+ *
+ * @author Brian Pontarelli
+ */
+export interface RegistrationRequest extends BaseEventRequest {
+  disableDomainBlock?: boolean;
+  generateAuthenticationToken?: boolean;
+  registration?: UserRegistration;
+  sendSetPasswordEmail?: boolean;
+  skipRegistrationVerification?: boolean;
+  skipVerification?: boolean;
+  user?: User;
+}
+
+/**
+ * Registration API request object.
+ *
+ * @author Brian Pontarelli
+ */
+export interface RegistrationResponse {
+  refreshToken?: string;
+  refreshTokenId?: UUID;
+  registration?: UserRegistration;
+  registrationVerificationId?: string;
+  registrationVerificationOneTimeCode?: string;
+  token?: string;
+  tokenExpirationInstant?: number;
+  user?: User;
+}
+
+/**
+ * @author Daniel DeGroff
+ */
+export interface RegistrationUnverifiedOptions {
+  behavior?: UnverifiedBehavior;
+}
+
+/**
+ * Reindex API request
+ *
+ * @author Daniel DeGroff
+ */
+export interface ReindexRequest {
+  index?: string;
+}
+
+/**
+ * @author Daniel DeGroff
+ */
+export interface ReloadRequest {
+  names?: Array<string>;
+}
+
+/**
+ * @author Daniel DeGroff
+ */
+export interface RememberPreviousPasswords extends Enableable {
+  count?: number;
+}
+
+/**
+ * Something that can be required and thus also optional. This currently extends Enableable because anything that is
+ * required/optional is almost always enableable as well.
+ *
+ * @author Brian Pontarelli
+ */
+export interface Requirable extends Enableable {
+  required?: boolean;
+}
+
+/**
+ * Interface describing the need for CORS configuration.
+ *
+ * @author Daniel DeGroff
+ */
+export interface RequiresCORSConfiguration {
+}
+
+/**
+ * Describes the Relying Party's requirements for <a href="https://www.w3.org/TR/webauthn-2/#client-side-discoverable-credential">client-side
+ * discoverable credentials</a> (formerly known as "resident keys")
+ *
+ * @author Spencer Witt
+ */
+export enum ResidentKeyRequirement {
+  discouraged = "discouraged",
+  preferred = "preferred",
+  required = "required"
+}
+
+/**
+ * @author Brian Pontarelli
+ */
+export interface SAMLv2ApplicationConfiguration extends BaseIdentityProviderApplicationConfiguration {
+  buttonImageURL?: string;
+  buttonText?: string;
+}
+
+/**
+ * @author Lyle Schemmerling
+ */
+export interface SAMLv2AssertionConfiguration {
+  destination?: SAMLv2DestinationAssertionConfiguration;
+}
+
+/**
+ * Configuration for encrypted assertions when acting as SAML Service Provider
+ *
+ * @author Jaret Hendrickson
+ */
+export interface SAMLv2AssertionDecryptionConfiguration extends Enableable {
+  keyTransportDecryptionKeyId?: UUID;
+}
+
+/**
+ * @author Lyle Schemmerling
+ */
+export interface SAMLv2DestinationAssertionConfiguration {
+  alternates?: Array<string>;
+  policy?: SAMLv2DestinationAssertionPolicy;
+}
+
+/**
+ * @author Lyle Schemmerling
+ */
+export enum SAMLv2DestinationAssertionPolicy {
+  Enabled = "Enabled",
+  Disabled = "Disabled",
+  AllowAlternates = "AllowAlternates"
+}
+
+/**
+ * @author Daniel DeGroff
+ */
+export interface SAMLv2IdPInitiatedApplicationConfiguration extends BaseIdentityProviderApplicationConfiguration {
+}
+
+/**
+ * SAML v2 IdP Initiated identity provider configuration.
+ *
+ * @author Daniel DeGroff
+ */
+export interface SAMLv2IdPInitiatedIdentityProvider extends BaseSAMLv2IdentityProvider<SAMLv2IdPInitiatedApplicationConfiguration> {
+  issuer?: string;
+}
+
+/**
+ * IdP Initiated login configuration
+ *
+ * @author Daniel DeGroff
+ */
+export interface SAMLv2IdPInitiatedLoginConfiguration extends Enableable {
+  nameIdFormat?: string;
+}
+
+/**
+ * SAML v2 identity provider configuration.
+ *
+ * @author Brian Pontarelli
+ */
+export interface SAMLv2IdentityProvider extends BaseSAMLv2IdentityProvider<SAMLv2ApplicationConfiguration> {
+  assertionConfiguration?: SAMLv2AssertionConfiguration;
+  buttonImageURL?: string;
+  buttonText?: string;
+  domains?: Array<string>;
+  idpEndpoint?: string;
+  idpInitiatedConfiguration?: SAMLv2IdpInitiatedConfiguration;
+  issuer?: string;
+  loginHintConfiguration?: LoginHintConfiguration;
+  nameIdFormat?: string;
+  postRequest?: boolean;
+  requestSigningKeyId?: UUID;
+  signRequest?: boolean;
+  xmlSignatureC14nMethod?: CanonicalizationMethod;
+}
+
+/**
+ * Config for regular SAML IDP configurations that support IdP initiated requests
+ *
+ * @author Lyle Schemmerling
+ */
+export interface SAMLv2IdpInitiatedConfiguration extends Enableable {
+  issuer?: string;
+}
+
+/**
+ * @author Michael Sleevi
+ */
+export interface SMSMessage {
+  phoneNumber?: string;
+  textMessage?: string;
+}
+
+/**
+ * @author Michael Sleevi
+ */
+export interface SMSMessageTemplate extends MessageTemplate {
+  defaultTemplate?: string;
+  localizedTemplates?: LocalizedStrings;
+}
+
+/**
+ * Search API request.
+ *
+ * @author Brian Pontarelli
+ */
+export interface SearchRequest extends ExpandableRequest {
+  search?: UserSearchCriteria;
+}
+
+/**
+ * Search API response.
+ *
+ * @author Brian Pontarelli
+ */
+export interface SearchResponse extends ExpandableResponse {
+  nextResults?: string;
+  total?: number;
+  users?: Array<User>;
+}
+
+/**
+ * Search results.
+ *
+ * @author Brian Pontarelli
+ */
+export interface SearchResults<T> {
+  nextResults?: string;
+  results?: Array<T>;
+  total?: number;
+  totalEqualToActual?: boolean;
+}
+
+/**
+ * @author Daniel DeGroff
+ */
+export interface SecretResponse {
+  secret?: string;
+  secretBase32Encoded?: string;
+}
+
+/**
+ * @author Daniel DeGroff
+ */
+export interface SecureGeneratorConfiguration {
+  length?: number;
+  type?: SecureGeneratorType;
+}
+
+/**
+ * @author Daniel DeGroff
+ */
+export enum SecureGeneratorType {
+  randomDigits = "randomDigits",
+  randomBytes = "randomBytes",
+  randomAlpha = "randomAlpha",
+  randomAlphaNumeric = "randomAlphaNumeric"
+}
+
+/**
+ * @author Daniel DeGroff
+ */
+export interface SecureIdentity {
+  breachedPasswordLastCheckedInstant?: number;
+  breachedPasswordStatus?: BreachedPasswordStatus;
+  connectorId?: UUID;
+  encryptionScheme?: string;
+  factor?: number;
+  id?: UUID;
+  lastLoginInstant?: number;
+  password?: string;
+  passwordChangeReason?: ChangePasswordReason;
+  passwordChangeRequired?: boolean;
+  passwordLastUpdateInstant?: number;
+  salt?: string;
+  uniqueUsername?: string;
+  username?: string;
+  usernameStatus?: ContentStatus;
+  verified?: boolean;
+  verifiedInstant?: number;
+}
+
+/**
+ * @author andrewpai
+ */
+export interface SelfServiceFormConfiguration {
+  requireCurrentPasswordOnPasswordChange?: boolean;
+}
+
+/**
+ * @author Daniel DeGroff
+ */
+export interface SendRequest {
+  applicationId?: UUID;
+  bccAddresses?: Array<string>;
+  ccAddresses?: Array<string>;
+  preferredLanguages?: Array<string>;
+  requestData?: Record<string, any>;
+  toAddresses?: Array<EmailAddress>;
+  userIds?: Array<UUID>;
+}
+
+/**
+ * @author Daniel DeGroff
+ */
+export interface SendResponse {
+  anonymousResults?: Record<string, EmailTemplateErrors>;
+  results?: Record<UUID, EmailTemplateErrors>;
+}
+
+export interface EmailTemplateErrors {
+  parseErrors?: Record<string, string>;
+  renderErrors?: Record<string, string>;
 }
 
 /**
@@ -10985,6 +10335,28 @@ export interface SimpleThemeVariables {
 }
 
 /**
+ * @author Brett Pontarelli
+ */
+export interface SonyPSNApplicationConfiguration extends BaseIdentityProviderApplicationConfiguration {
+  buttonText?: string;
+  client_id?: string;
+  client_secret?: string;
+  scope?: string;
+}
+
+/**
+ * SonyPSN gaming login provider.
+ *
+ * @author Brett Pontarelli
+ */
+export interface SonyPSNIdentityProvider extends BaseIdentityProvider<SonyPSNApplicationConfiguration> {
+  buttonText?: string;
+  client_id?: string;
+  client_secret?: string;
+  scope?: string;
+}
+
+/**
  * @author Daniel DeGroff
  */
 export enum Sort {
@@ -10993,81 +10365,304 @@ export enum Sort {
 }
 
 /**
- * Event to indicate an audit log was created.
+ * @author Daniel DeGroff
+ */
+export interface SortField {
+  missing?: string;
+  name?: string;
+  order?: Sort;
+}
+
+/**
+ * The public Status API response
  *
  * @author Daniel DeGroff
  */
-export interface AuditLogCreateEvent extends BaseEvent {
-  auditLog?: AuditLog;
+export interface StatusResponse extends Record<string, any> {
 }
 
 /**
- * Describes the authenticator attachment modality preference for a WebAuthn workflow. See {@link AuthenticatorAttachment}
+ * Steam API modes.
  *
- * @author Spencer Witt
- */
-export enum AuthenticatorAttachmentPreference {
-  any = "any",
-  platform = "platform",
-  crossPlatform = "crossPlatform"
-}
-
-/**
- * User API bulk response object.
- *
- * @author Trevor Smith
- */
-export interface UserDeleteResponse {
-  dryRun?: boolean;
-  hardDelete?: boolean;
-  total?: number;
-  userIds?: Array<UUID>;
-}
-
-/**
  * @author Daniel DeGroff
  */
-export interface TwoFactorStartResponse {
-  code?: string;
-  methods?: Array<TwoFactorMethod>;
-  twoFactorId?: string;
+export enum SteamAPIMode {
+  Public = "Public",
+  Partner = "Partner"
 }
 
 /**
- * User Action Reason API response object.
+ * @author Brett Pontarelli
+ */
+export interface SteamApplicationConfiguration extends BaseIdentityProviderApplicationConfiguration {
+  apiMode?: SteamAPIMode;
+  buttonText?: string;
+  client_id?: string;
+  scope?: string;
+  webAPIKey?: string;
+}
+
+/**
+ * Steam gaming login provider.
+ *
+ * @author Brett Pontarelli
+ */
+export interface SteamIdentityProvider extends BaseIdentityProvider<SteamApplicationConfiguration> {
+  apiMode?: SteamAPIMode;
+  buttonText?: string;
+  client_id?: string;
+  scope?: string;
+  webAPIKey?: string;
+}
+
+/**
+ * Helper interface that indicates an identity provider can be federated to using the HTTP POST method.
  *
  * @author Brian Pontarelli
  */
-export interface UserActionReasonResponse {
-  userActionReason?: UserActionReason;
-  userActionReasons?: Array<UserActionReason>;
+export interface SupportsPostBindings {
 }
 
 /**
- * Models the User Event (and can be converted to JSON) that is used for all user modifications (create, update,
- * delete).
+ * @author Brian Pontarelli
+ */
+export interface SystemConfiguration {
+  auditLogConfiguration?: AuditLogConfiguration;
+  corsConfiguration?: CORSConfiguration;
+  data?: Record<string, any>;
+  eventLogConfiguration?: EventLogConfiguration;
+  insertInstant?: number;
+  lastUpdateInstant?: number;
+  loginRecordConfiguration?: LoginRecordConfiguration;
+  reportTimezone?: string;
+  trustedProxyConfiguration?: SystemTrustedProxyConfiguration;
+  uiConfiguration?: UIConfiguration;
+  usageDataConfiguration?: UsageDataConfiguration;
+  webhookEventLogConfiguration?: WebhookEventLogConfiguration;
+}
+
+export interface AuditLogConfiguration {
+  delete?: DeleteConfiguration;
+}
+
+export interface DeleteConfiguration extends Enableable {
+  numberOfDaysToRetain?: number;
+}
+
+export interface EventLogConfiguration {
+  numberToRetain?: number;
+}
+
+export interface LoginRecordConfiguration {
+  delete?: DeleteConfiguration;
+}
+
+export interface UIConfiguration {
+  headerColor?: string;
+  logoURL?: string;
+  menuFontColor?: string;
+}
+
+/**
+ * Request for the system configuration API.
  *
  * @author Brian Pontarelli
  */
-export interface UserDeleteEvent extends BaseUserEvent {
+export interface SystemConfigurationRequest {
+  systemConfiguration?: SystemConfiguration;
 }
 
 /**
- * An expandable API request.
+ * Response for the system configuration API.
  *
- * @author Daniel DeGroff
+ * @author Brian Pontarelli
  */
-export interface ExpandableRequest {
-  expand?: Array<string>;
+export interface SystemConfigurationResponse {
+  systemConfiguration?: SystemConfiguration;
 }
 
 /**
- * API response for User consent.
- *
  * @author Daniel DeGroff
  */
-export interface UserConsentRequest {
-  userConsent?: UserConsent;
+export interface SystemLogsExportRequest extends BaseExportRequest {
+  includeArchived?: boolean;
+  lastNBytes?: number;
+}
+
+/**
+ * @author Daniel DeGroff
+ */
+export interface SystemTrustedProxyConfiguration {
+  trusted?: Array<string>;
+  trustPolicy?: SystemTrustedProxyConfigurationPolicy;
+}
+
+/**
+ * @author Daniel DeGroff
+ */
+export enum SystemTrustedProxyConfigurationPolicy {
+  All = "All",
+  OnlyConfigured = "OnlyConfigured"
+}
+
+/**
+ * @author Daniel DeGroff
+ */
+export interface Tenant {
+  accessControlConfiguration?: TenantAccessControlConfiguration;
+  captchaConfiguration?: TenantCaptchaConfiguration;
+  configured?: boolean;
+  connectorPolicies?: Array<ConnectorPolicy>;
+  data?: Record<string, any>;
+  emailConfiguration?: EmailConfiguration;
+  eventConfiguration?: EventConfiguration;
+  externalIdentifierConfiguration?: ExternalIdentifierConfiguration;
+  failedAuthenticationConfiguration?: FailedAuthenticationConfiguration;
+  familyConfiguration?: FamilyConfiguration;
+  formConfiguration?: TenantFormConfiguration;
+  httpSessionMaxInactiveInterval?: number;
+  id?: UUID;
+  insertInstant?: number;
+  issuer?: string;
+  jwtConfiguration?: JWTConfiguration;
+  lambdaConfiguration?: TenantLambdaConfiguration;
+  lastUpdateInstant?: number;
+  loginConfiguration?: TenantLoginConfiguration;
+  logoutURL?: string;
+  maximumPasswordAge?: MaximumPasswordAge;
+  minimumPasswordAge?: MinimumPasswordAge;
+  multiFactorConfiguration?: TenantMultiFactorConfiguration;
+  name?: string;
+  oauthConfiguration?: TenantOAuth2Configuration;
+  passwordEncryptionConfiguration?: PasswordEncryptionConfiguration;
+  passwordValidationRules?: PasswordValidationRules;
+  rateLimitConfiguration?: TenantRateLimitConfiguration;
+  registrationConfiguration?: TenantRegistrationConfiguration;
+  scimServerConfiguration?: TenantSCIMServerConfiguration;
+  ssoConfiguration?: TenantSSOConfiguration;
+  state?: ObjectState;
+  themeId?: UUID;
+  userDeletePolicy?: TenantUserDeletePolicy;
+  usernameConfiguration?: TenantUsernameConfiguration;
+  webAuthnConfiguration?: TenantWebAuthnConfiguration;
+}
+
+export interface TenantOAuth2Configuration {
+  clientCredentialsAccessTokenPopulateLambdaId?: UUID;
+}
+
+/**
+ * @author Brett Guy
+ */
+export interface TenantAccessControlConfiguration {
+  uiIPAccessControlListId?: UUID;
+}
+
+/**
+ * @author Brett Pontarelli
+ */
+export interface TenantCaptchaConfiguration extends Enableable {
+  captchaMethod?: CaptchaMethod;
+  secretKey?: string;
+  siteKey?: string;
+  threshold?: number;
+}
+
+/**
+ * Request for the Tenant API to delete a tenant rather than using the URL parameters.
+ *
+ * @author Brian Pontarelli
+ */
+export interface TenantDeleteRequest extends BaseEventRequest {
+  async?: boolean;
+}
+
+/**
+ * @author Daniel DeGroff
+ */
+export interface TenantFormConfiguration {
+  adminUserFormId?: UUID;
+}
+
+/**
+ * @author Rob Davis
+ */
+export interface TenantLambdaConfiguration {
+  loginValidationId?: UUID;
+  scimEnterpriseUserRequestConverterId?: UUID;
+  scimEnterpriseUserResponseConverterId?: UUID;
+  scimGroupRequestConverterId?: UUID;
+  scimGroupResponseConverterId?: UUID;
+  scimUserRequestConverterId?: UUID;
+  scimUserResponseConverterId?: UUID;
+}
+
+/**
+ * @author Daniel DeGroff
+ */
+export interface TenantLoginConfiguration {
+  requireAuthentication?: boolean;
+}
+
+/**
+ * @author Mikey Sleevi
+ */
+export interface TenantMultiFactorConfiguration {
+  authenticator?: MultiFactorAuthenticatorMethod;
+  email?: MultiFactorEmailMethod;
+  loginPolicy?: MultiFactorLoginPolicy;
+  sms?: MultiFactorSMSMethod;
+}
+
+export interface MultiFactorAuthenticatorMethod extends Enableable {
+  algorithm?: TOTPAlgorithm;
+  codeLength?: number;
+  timeStep?: number;
+}
+
+export interface MultiFactorEmailMethod extends Enableable {
+  templateId?: UUID;
+}
+
+export interface MultiFactorSMSMethod extends Enableable {
+  messengerId?: UUID;
+  templateId?: UUID;
+}
+
+/**
+ * @author Daniel DeGroff
+ */
+export interface TenantRateLimitConfiguration {
+  failedLogin?: RateLimitedRequestConfiguration;
+  forgotPassword?: RateLimitedRequestConfiguration;
+  sendEmailVerification?: RateLimitedRequestConfiguration;
+  sendPasswordless?: RateLimitedRequestConfiguration;
+  sendRegistrationVerification?: RateLimitedRequestConfiguration;
+  sendTwoFactor?: RateLimitedRequestConfiguration;
+}
+
+/**
+ * @author Daniel DeGroff
+ */
+export interface TenantRegistrationConfiguration {
+  blockedDomains?: Array<string>;
+}
+
+/**
+ * @author Daniel DeGroff
+ */
+export interface TenantRequest extends BaseEventRequest {
+  sourceTenantId?: UUID;
+  tenant?: Tenant;
+  webhookIds?: Array<UUID>;
+}
+
+/**
+ * @author Daniel DeGroff
+ */
+export interface TenantResponse {
+  tenant?: Tenant;
+  tenants?: Array<Tenant>;
 }
 
 /**
@@ -11080,437 +10675,11 @@ export interface TenantSCIMServerConfiguration extends Enableable {
 }
 
 /**
- * Theme API request object.
- *
- * @author Trevor Smith
- */
-export interface ThemeRequest {
-  sourceThemeId?: UUID;
-  theme?: Theme;
-}
-
-/**
- * @author Daniel DeGroff
- */
-export interface OAuthConfigurationResponse {
-  httpSessionMaxInactiveInterval?: number;
-  logoutURL?: string;
-  oauthConfiguration?: OAuth2Configuration;
-}
-
-/**
- * @author Daniel DeGroff
- */
-export interface ExternalIdentifierConfiguration {
-  authorizationGrantIdTimeToLiveInSeconds?: number;
-  changePasswordIdGenerator?: SecureGeneratorConfiguration;
-  changePasswordIdTimeToLiveInSeconds?: number;
-  deviceCodeTimeToLiveInSeconds?: number;
-  deviceUserCodeIdGenerator?: SecureGeneratorConfiguration;
-  emailVerificationIdGenerator?: SecureGeneratorConfiguration;
-  emailVerificationIdTimeToLiveInSeconds?: number;
-  emailVerificationOneTimeCodeGenerator?: SecureGeneratorConfiguration;
-  externalAuthenticationIdTimeToLiveInSeconds?: number;
-  loginIntentTimeToLiveInSeconds?: number;
-  oneTimePasswordTimeToLiveInSeconds?: number;
-  passwordlessLoginGenerator?: SecureGeneratorConfiguration;
-  passwordlessLoginTimeToLiveInSeconds?: number;
-  pendingAccountLinkTimeToLiveInSeconds?: number;
-  registrationVerificationIdGenerator?: SecureGeneratorConfiguration;
-  registrationVerificationIdTimeToLiveInSeconds?: number;
-  registrationVerificationOneTimeCodeGenerator?: SecureGeneratorConfiguration;
-  rememberOAuthScopeConsentChoiceTimeToLiveInSeconds?: number;
-  samlv2AuthNRequestIdTimeToLiveInSeconds?: number;
-  setupPasswordIdGenerator?: SecureGeneratorConfiguration;
-  setupPasswordIdTimeToLiveInSeconds?: number;
-  trustTokenTimeToLiveInSeconds?: number;
-  twoFactorIdTimeToLiveInSeconds?: number;
-  twoFactorOneTimeCodeIdGenerator?: SecureGeneratorConfiguration;
-  twoFactorOneTimeCodeIdTimeToLiveInSeconds?: number;
-  twoFactorTrustIdTimeToLiveInSeconds?: number;
-  webAuthnAuthenticationChallengeTimeToLiveInSeconds?: number;
-  webAuthnRegistrationChallengeTimeToLiveInSeconds?: number;
-}
-
-/**
- * Defines valid credential types. This is an extension point in the WebAuthn spec. The only defined value at this time is "public-key"
- *
- * @author Spencer Witt
- */
-export enum PublicKeyCredentialType {
-  publicKey = "public-key"
-}
-
-/**
- * This class is the entity query. It provides a build pattern as well as public fields for use on forms and in actions.
- *
- * @author Brian Pontarelli
- */
-export interface EntitySearchCriteria extends BaseElasticSearchCriteria {
-}
-
-/**
- * @author Seth Musselman
- */
-export interface PreviewResponse {
-  email?: Email;
-  errors?: Errors;
-}
-
-/**
- * @author Brett Pontarelli
- */
-export interface EpicGamesApplicationConfiguration extends BaseIdentityProviderApplicationConfiguration {
-  buttonText?: string;
-  client_id?: string;
-  client_secret?: string;
-  scope?: string;
-}
-
-/**
- * OpenID Connect Configuration as described by the <a href="https://openid.net/specs/openid-connect-discovery-1_0.html#ProviderMetadata">OpenID
- * Provider Metadata</a>.
- *
- * @author Daniel DeGroff
- */
-export interface OpenIdConfiguration {
-  authorization_endpoint?: string;
-  backchannel_logout_supported?: boolean;
-  claims_supported?: Array<string>;
-  device_authorization_endpoint?: string;
-  end_session_endpoint?: string;
-  frontchannel_logout_supported?: boolean;
-  grant_types_supported?: Array<string>;
-  id_token_signing_alg_values_supported?: Array<string>;
-  issuer?: string;
-  jwks_uri?: string;
-  response_modes_supported?: Array<string>;
-  response_types_supported?: Array<string>;
-  scopes_supported?: Array<string>;
-  subject_types_supported?: Array<string>;
-  token_endpoint?: string;
-  token_endpoint_auth_methods_supported?: Array<string>;
-  userinfo_endpoint?: string;
-  userinfo_signing_alg_values_supported?: Array<string>;
-}
-
-/**
- * COSE Elliptic Curve identifier to determine which elliptic curve to use with a given key
- *
- * @author Spencer Witt
- */
-export enum CoseEllipticCurve {
-  Reserved = "Reserved",
-  P256 = "P256",
-  P384 = "P384",
-  P521 = "P521",
-  X25519 = "X25519",
-  X448 = "X448",
-  Ed25519 = "Ed25519",
-  Ed448 = "Ed448",
-  Secp256k1 = "Secp256k1"
-}
-
-/**
- * Form response.
- *
- * @author Daniel DeGroff
- */
-export interface FormResponse {
-  form?: Form;
-  forms?: Array<Form>;
-}
-
-// Do not require a setter for 'type', it is defined by the concrete class and is not mutable
-export interface BaseIdentityProvider<D extends BaseIdentityProviderApplicationConfiguration> extends Enableable {
-  applicationConfiguration?: Record<UUID, D>;
-  data?: Record<string, any>;
-  debug?: boolean;
-  id?: UUID;
-  insertInstant?: number;
-  lambdaConfiguration?: LambdaConfiguration;
-  lastUpdateInstant?: number;
-  linkingStrategy?: IdentityProviderLinkingStrategy;
-  name?: string;
-  tenantConfiguration?: Record<UUID, IdentityProviderTenantConfiguration>;
-  type?: IdentityProviderType;
-}
-
-export interface LambdaConfiguration {
-  reconcileId?: UUID;
-}
-
-/**
- * @author Daniel DeGroff
- */
-export interface ValidateResponse {
-  jwt?: JWT;
-}
-
-/**
- * @author Daniel DeGroff
- */
-export interface VerifyRegistrationResponse {
-  oneTimeCode?: string;
-  verificationId?: string;
-}
-
-/**
- * @author Daniel DeGroff
- */
-export interface LoginRecordSearchCriteria extends BaseSearchCriteria {
-  applicationId?: UUID;
-  end?: number;
-  start?: number;
-  userId?: UUID;
-}
-
-/**
- * @author Daniel DeGroff
- */
-export interface OAuthResponse {
-}
-
-/**
- * Domain for a public key, key pair or an HMAC secret. This is used by KeyMaster to manage keys for JWTs, SAML, etc.
- *
- * @author Brian Pontarelli
- */
-export interface Key {
-  algorithm?: KeyAlgorithm;
-  certificate?: string;
-  certificateInformation?: CertificateInformation;
-  expirationInstant?: number;
-  hasPrivateKey?: boolean;
-  id?: UUID;
-  insertInstant?: number;
-  issuer?: string;
-  kid?: string;
-  lastUpdateInstant?: number;
-  length?: number;
-  name?: string;
-  privateKey?: string;
-  publicKey?: string;
-  secret?: string;
-  type?: KeyType;
-}
-
-export enum KeyAlgorithm {
-  ES256 = "ES256",
-  ES384 = "ES384",
-  ES512 = "ES512",
-  HS256 = "HS256",
-  HS384 = "HS384",
-  HS512 = "HS512",
-  RS256 = "RS256",
-  RS384 = "RS384",
-  RS512 = "RS512"
-}
-
-export enum KeyType {
-  EC = "EC",
-  RSA = "RSA",
-  HMAC = "HMAC"
-}
-
-export interface CertificateInformation {
-  issuer?: string;
-  md5Fingerprint?: string;
-  serialNumber?: string;
-  sha1Fingerprint?: string;
-  sha1Thumbprint?: string;
-  sha256Fingerprint?: string;
-  sha256Thumbprint?: string;
-  subject?: string;
-  validFrom?: number;
-  validTo?: number;
-}
-
-/**
- * @author Trevor Smith
- */
-export interface ConnectorResponse {
-  connector?: BaseConnectorConfiguration;
-  connectors?: Array<BaseConnectorConfiguration>;
-}
-
-/**
- * Models the FusionAuth connector.
- *
- * @author Trevor Smith
- */
-export interface FusionAuthConnectorConfiguration extends BaseConnectorConfiguration {
-}
-
-/**
- * Controls the policy for requesting user permission to grant access to requested scopes during an OAuth workflow
- * for a third-party application.
- *
- * @author Spencer Witt
- */
-export enum OAuthScopeConsentMode {
-  AlwaysPrompt = "AlwaysPrompt",
-  RememberDecision = "RememberDecision",
-  NeverPrompt = "NeverPrompt"
-}
-
-/**
- * Search criteria for entity grants.
- *
- * @author Brian Pontarelli
- */
-export interface EntityGrantSearchCriteria extends BaseSearchCriteria {
-  entityId?: UUID;
-  name?: string;
-  userId?: UUID;
-}
-
-/**
- * @author Daniel DeGroff
- */
-export interface RefreshTokenSlidingWindowConfiguration {
-  maximumTimeToLiveInMinutes?: number;
-}
-
-/**
- * Search request for Themes.
- *
- * @author Mark Manes
- */
-export interface ThemeSearchRequest {
-  search?: ThemeSearchCriteria;
-}
-
-/**
- * @author Daniel DeGroff
- */
-export enum ObjectState {
-  Active = "Active",
-  Inactive = "Inactive",
-  PendingDelete = "PendingDelete"
-}
-
-/**
- * Search request for Consents
- *
- * @author Spencer Witt
- */
-export interface ConsentSearchRequest {
-  search?: ConsentSearchCriteria;
-}
-
-/**
- * Search request for Identity Providers
- *
- * @author Spencer Witt
- */
-export interface IdentityProviderSearchRequest {
-  search?: IdentityProviderSearchCriteria;
-}
-
-/**
- * @author Daniel DeGroff
- */
-export interface RefreshTokenRevocationPolicy {
-  onLoginPrevented?: boolean;
-  onMultiFactorEnable?: boolean;
-  onOneTimeTokenReuse?: boolean;
-  onPasswordChanged?: boolean;
-}
-
-/**
- * Models a family grouping of users.
- *
- * @author Brian Pontarelli
- */
-export interface Family {
-  id?: UUID;
-  insertInstant?: number;
-  lastUpdateInstant?: number;
-  members?: Array<FamilyMember>;
-}
-
-/**
- * The Application Scope API response.
- *
- * @author Spencer Witt
- */
-export interface ApplicationOAuthScopeResponse {
-  scope?: ApplicationOAuthScope;
-}
-
-/**
- * @author Daniel DeGroff
- */
-export interface OAuth2Configuration {
-  authorizedOriginURLs?: Array<string>;
-  authorizedRedirectURLs?: Array<string>;
-  authorizedURLValidationPolicy?: Oauth2AuthorizedURLValidationPolicy;
-  clientAuthenticationPolicy?: ClientAuthenticationPolicy;
-  clientId?: string;
-  clientSecret?: string;
-  consentMode?: OAuthScopeConsentMode;
-  debug?: boolean;
-  deviceVerificationURL?: string;
-  enabledGrants?: Array<GrantType>;
-  generateRefreshTokens?: boolean;
-  logoutBehavior?: LogoutBehavior;
-  logoutURL?: string;
-  proofKeyForCodeExchangePolicy?: ProofKeyForCodeExchangePolicy;
-  providedScopePolicy?: ProvidedScopePolicy;
-  relationship?: OAuthApplicationRelationship;
-  requireClientAuthentication?: boolean;
-  requireRegistration?: boolean;
-  scopeHandlingPolicy?: OAuthScopeHandlingPolicy;
-  unknownScopePolicy?: UnknownScopePolicy;
-}
-
-/**
- * Interface for all identity providers that are passwordless and do not accept a password.
- */
-export interface PasswordlessIdentityProvider {
-}
-
-/**
- * A log for an event that happened to a User.
- *
- * @author Brian Pontarelli
- */
-export interface UserComment {
-  comment?: string;
-  commenterId?: UUID;
-  id?: UUID;
-  insertInstant?: number;
-  userId?: UUID;
-}
-
-/**
- * Models the Group Created Event.
- *
- * @author Daniel DeGroff
- */
-export interface GroupCreateCompleteEvent extends BaseGroupEvent {
-}
-
-/**
  * @author Brett Pontarelli
  */
 export interface TenantSSOConfiguration {
   allowAccessTokenBootstrap?: boolean;
   deviceTrustTimeToLiveInSeconds?: number;
-}
-
-/**
- * @author Daniel DeGroff
- */
-export interface TwoFactorMethod {
-  authenticator?: AuthenticatorConfiguration;
-  email?: string;
-  id?: string;
-  lastUsed?: boolean;
-  method?: string;
-  mobilePhone?: string;
-  secret?: string;
 }
 
 /**
@@ -11523,58 +10692,91 @@ export interface TenantSearchCriteria extends BaseSearchCriteria {
 }
 
 /**
- * Models the User Identity Provider Link Event.
+ * Search request for Tenants
  *
- * @author Rob Davis
+ * @author Mark Manes
  */
-export interface UserIdentityProviderLinkEvent extends BaseUserEvent {
-  identityProviderLink?: IdentityProviderLink;
+export interface TenantSearchRequest {
+  search?: TenantSearchCriteria;
 }
 
 /**
- * @author Michael Sleevi
+ * Tenant search response
+ *
+ * @author Mark Manes
  */
-export interface PreviewMessageTemplateRequest {
-  locale?: string;
-  messageTemplate?: MessageTemplate;
+export interface TenantSearchResponse {
+  tenants?: Array<Tenant>;
+  total?: number;
 }
 
 /**
- * Login API request object used for login to third-party systems (i.e. Login with Facebook).
+ * @author Daniel DeGroff
+ */
+export interface TenantUnverifiedConfiguration {
+  email?: UnverifiedBehavior;
+  whenGated?: RegistrationUnverifiedOptions;
+}
+
+/**
+ * A Tenant-level policy for deleting Users.
  *
+ * @author Trevor Smith
+ */
+export interface TenantUserDeletePolicy {
+  unverified?: TimeBasedDeletePolicy;
+}
+
+/**
+ * @author Daniel DeGroff
+ */
+export interface TenantUsernameConfiguration {
+  unique?: UniqueUsernameConfiguration;
+}
+
+export interface UniqueUsernameConfiguration extends Enableable {
+  numberOfDigits?: number;
+  separator?: string;
+  strategy?: UniqueUsernameStrategy;
+}
+
+export enum UniqueUsernameStrategy {
+  Always = "Always",
+  OnCollision = "OnCollision"
+}
+
+/**
+ * Tenant-level configuration for WebAuthn
+ *
+ * @author Spencer Witt
+ */
+export interface TenantWebAuthnConfiguration extends Enableable {
+  bootstrapWorkflow?: TenantWebAuthnWorkflowConfiguration;
+  debug?: boolean;
+  reauthenticationWorkflow?: TenantWebAuthnWorkflowConfiguration;
+  relyingPartyId?: string;
+  relyingPartyName?: string;
+}
+
+/**
+ * @author Spencer Witt
+ */
+export interface TenantWebAuthnWorkflowConfiguration extends Enableable {
+  authenticatorAttachmentPreference?: AuthenticatorAttachmentPreference;
+  userVerificationRequirement?: UserVerificationRequirement;
+}
+
+/**
  * @author Brian Pontarelli
  */
-export interface IdentityProviderLoginRequest extends BaseLoginRequest {
-  data?: Record<string, string>;
-  encodedJWT?: string;
-  identityProviderId?: UUID;
-  noLink?: boolean;
+export interface Tenantable {
 }
 
 /**
- * An action that can be executed on a user (discipline or reward potentially).
- *
- * @author Brian Pontarelli
+ * @author Daniel DeGroff
  */
-export interface UserAction {
-  active?: boolean;
-  cancelEmailTemplateId?: UUID;
-  endEmailTemplateId?: UUID;
-  id?: UUID;
-  includeEmailInEventJSON?: boolean;
-  insertInstant?: number;
-  lastUpdateInstant?: number;
-  localizedNames?: LocalizedStrings;
-  modifyEmailTemplateId?: UUID;
-  name?: string;
-  options?: Array<UserActionOption>;
-  preventLogin?: boolean;
-  sendEndEvent?: boolean;
-  startEmailTemplateId?: UUID;
-  temporal?: boolean;
-  transactionType?: TransactionType;
-  userEmailingEnabled?: boolean;
-  userNotificationsEnabled?: boolean;
+export interface TestEvent extends BaseEvent {
+  message?: string;
 }
 
 /**
@@ -11646,80 +10848,444 @@ export interface Templates {
 }
 
 /**
+ * Theme API request object.
+ *
+ * @author Trevor Smith
+ */
+export interface ThemeRequest {
+  sourceThemeId?: UUID;
+  theme?: Theme;
+}
+
+/**
+ * Theme API response object.
+ *
+ * @author Trevor Smith
+ */
+export interface ThemeResponse {
+  theme?: Theme;
+  themes?: Array<Theme>;
+}
+
+/**
+ * Search criteria for themes
+ *
+ * @author Mark Manes
+ */
+export interface ThemeSearchCriteria extends BaseSearchCriteria {
+  name?: string;
+  type?: ThemeType;
+}
+
+/**
+ * Search request for Themes.
+ *
+ * @author Mark Manes
+ */
+export interface ThemeSearchRequest {
+  search?: ThemeSearchCriteria;
+}
+
+/**
+ * Search response for Themes
+ *
+ * @author Mark Manes
+ */
+export interface ThemeSearchResponse {
+  themes?: Array<Theme>;
+  total?: number;
+}
+
+export enum ThemeType {
+  advanced = "advanced",
+  simple = "simple"
+}
+
+/**
+ * A policy for deleting Users based upon some external criteria.
+ *
+ * @author Trevor Smith
+ */
+export interface TimeBasedDeletePolicy extends Enableable {
+  enabledInstant?: number;
+  numberOfDaysToRetain?: number;
+}
+
+/**
+ * <ul>
+ * <li>Bearer Token type as defined by <a href="https://tools.ietf.org/html/rfc6750">RFC 6750</a>.</li>
+ * <li>MAC Token type as referenced by <a href="https://tools.ietf.org/html/rfc6749">RFC 6749</a> and
+ * <a href="https://tools.ietf.org/html/draft-ietf-oauth-v2-http-mac-05">
+ * Draft RFC on OAuth 2.0 Message Authentication Code (MAC) Tokens</a>
+ * </li>
+ * </ul>
+ *
  * @author Daniel DeGroff
  */
-export enum IdentityProviderType {
-  Apple = "Apple",
-  EpicGames = "EpicGames",
-  ExternalJWT = "ExternalJWT",
-  Facebook = "Facebook",
-  Google = "Google",
-  HYPR = "HYPR",
-  LinkedIn = "LinkedIn",
-  Nintendo = "Nintendo",
-  OpenIDConnect = "OpenIDConnect",
-  SAMLv2 = "SAMLv2",
-  SAMLv2IdPInitiated = "SAMLv2IdPInitiated",
-  SonyPSN = "SonyPSN",
-  Steam = "Steam",
-  Twitch = "Twitch",
-  Twitter = "Twitter",
-  Xbox = "Xbox"
+export enum TokenType {
+  Bearer = "Bearer",
+  MAC = "MAC"
+}
+
+/**
+ * The response from the total report. This report stores the total numbers for each application.
+ *
+ * @author Brian Pontarelli
+ */
+export interface TotalsReportResponse {
+  applicationTotals?: Record<UUID, Totals>;
+  globalRegistrations?: number;
+  totalGlobalRegistrations?: number;
+}
+
+export interface Totals {
+  logins?: number;
+  registrations?: number;
+  totalRegistrations?: number;
+}
+
+/**
+ * The transaction types for Webhooks and other event systems within FusionAuth.
+ *
+ * @author Brian Pontarelli
+ */
+export enum TransactionType {
+  None = "None",
+  Any = "Any",
+  SimpleMajority = "SimpleMajority",
+  SuperMajority = "SuperMajority",
+  AbsoluteMajority = "AbsoluteMajority"
 }
 
 /**
  * @author Brett Guy
  */
-export interface IPAccessControlList {
+export interface TwilioMessengerConfiguration extends BaseMessengerConfiguration {
+  accountSID?: string;
+  authToken?: string;
+  fromPhoneNumber?: string;
+  messagingServiceSid?: string;
+  url?: string;
+}
+
+/**
+ * @author Brett Pontarelli
+ */
+export interface TwitchApplicationConfiguration extends BaseIdentityProviderApplicationConfiguration {
+  buttonText?: string;
+  client_id?: string;
+  client_secret?: string;
+  scope?: string;
+}
+
+/**
+ * Twitch gaming login provider.
+ *
+ * @author Brett Pontarelli
+ */
+export interface TwitchIdentityProvider extends BaseIdentityProvider<TwitchApplicationConfiguration> {
+  buttonText?: string;
+  client_id?: string;
+  client_secret?: string;
+  scope?: string;
+}
+
+/**
+ * @author Daniel DeGroff
+ */
+export interface TwitterApplicationConfiguration extends BaseIdentityProviderApplicationConfiguration {
+  buttonText?: string;
+  consumerKey?: string;
+  consumerSecret?: string;
+}
+
+/**
+ * Twitter social login provider.
+ *
+ * @author Daniel DeGroff
+ */
+export interface TwitterIdentityProvider extends BaseIdentityProvider<TwitterApplicationConfiguration> {
+  buttonText?: string;
+  consumerKey?: string;
+  consumerSecret?: string;
+}
+
+/**
+ * @author Brian Pontarelli
+ */
+export interface TwoFactorDisableRequest extends BaseEventRequest {
+  applicationId?: UUID;
+  code?: string;
+  methodId?: string;
+}
+
+/**
+ * @author Daniel DeGroff
+ */
+export interface TwoFactorEnableDisableSendRequest {
+  email?: string;
+  method?: string;
+  methodId?: string;
+  mobilePhone?: string;
+}
+
+/**
+ * @author Daniel DeGroff
+ */
+export interface TwoFactorLoginRequest extends BaseLoginRequest {
+  code?: string;
+  trustComputer?: boolean;
+  twoFactorId?: string;
+  userId?: UUID;
+}
+
+/**
+ * @author Daniel DeGroff
+ */
+export interface TwoFactorMethod {
+  authenticator?: AuthenticatorConfiguration;
+  email?: string;
+  id?: string;
+  lastUsed?: boolean;
+  method?: string;
+  mobilePhone?: string;
+  secret?: string;
+}
+
+/**
+ * @author Daniel DeGroff
+ */
+export interface TwoFactorRecoveryCodeResponse {
+  recoveryCodes?: Array<string>;
+}
+
+/**
+ * @author Brian Pontarelli
+ */
+export interface TwoFactorRequest extends BaseEventRequest {
+  applicationId?: UUID;
+  authenticatorId?: string;
+  code?: string;
+  email?: string;
+  method?: string;
+  mobilePhone?: string;
+  secret?: string;
+  secretBase32Encoded?: string;
+  twoFactorId?: string;
+}
+
+/**
+ * @author Daniel DeGroff
+ */
+export interface TwoFactorResponse {
+  code?: string;
+  recoveryCodes?: Array<string>;
+}
+
+/**
+ * @author Daniel DeGroff
+ */
+export interface TwoFactorSendRequest {
+  applicationId?: UUID;
+  email?: string;
+  method?: string;
+  methodId?: string;
+  mobilePhone?: string;
+  userId?: UUID;
+}
+
+/**
+ * @author Brett Guy
+ */
+export interface TwoFactorStartRequest {
+  applicationId?: UUID;
+  code?: string;
+  loginId?: string;
+  state?: Record<string, any>;
+  trustChallenge?: string;
+  userId?: UUID;
+}
+
+/**
+ * @author Daniel DeGroff
+ */
+export interface TwoFactorStartResponse {
+  code?: string;
+  methods?: Array<TwoFactorMethod>;
+  twoFactorId?: string;
+}
+
+/**
+ * @author Daniel DeGroff
+ */
+export interface TwoFactorStatusResponse {
+  trusts?: Array<TwoFactorTrust>;
+  twoFactorTrustId?: string;
+}
+
+export interface TwoFactorTrust {
+  applicationId?: UUID;
+  expiration?: number;
+  startInstant?: number;
+}
+
+/**
+ * Policy for handling unknown OAuth scopes in the request
+ *
+ * @author Spencer Witt
+ */
+export enum UnknownScopePolicy {
+  Allow = "Allow",
+  Remove = "Remove",
+  Reject = "Reject"
+}
+
+/**
+ * @author Daniel DeGroff
+ */
+export enum UnverifiedBehavior {
+  Allow = "Allow",
+  Gated = "Gated"
+}
+
+/**
+ * Config for Usage Data / Stats
+ *
+ * @author Lyle Schemmerling
+ */
+export interface UsageDataConfiguration extends Enableable {
+  numberOfDaysToRetain?: number;
+}
+
+/**
+ * The global view of a User. This object contains all global information about the user including birthdate, registration information
+ * preferred languages, global attributes, etc.
+ *
+ * @author Seth Musselman
+ */
+export interface User extends SecureIdentity {
+  active?: boolean;
+  birthDate?: string;
+  cleanSpeakId?: UUID;
   data?: Record<string, any>;
-  entries?: Array<IPAccessControlEntry>;
+  email?: string;
+  expiry?: number;
+  firstName?: string;
+  fullName?: string;
+  imageUrl?: string;
+  insertInstant?: number;
+  lastName?: string;
+  lastUpdateInstant?: number;
+  memberships?: Array<GroupMember>;
+  middleName?: string;
+  mobilePhone?: string;
+  parentEmail?: string;
+  preferredLanguages?: Array<string>;
+  registrations?: Array<UserRegistration>;
+  tenantId?: UUID;
+  timezone?: string;
+  twoFactor?: UserTwoFactorConfiguration;
+}
+
+/**
+ * An action that can be executed on a user (discipline or reward potentially).
+ *
+ * @author Brian Pontarelli
+ */
+export interface UserAction {
+  active?: boolean;
+  cancelEmailTemplateId?: UUID;
+  endEmailTemplateId?: UUID;
   id?: UUID;
+  includeEmailInEventJSON?: boolean;
   insertInstant?: number;
   lastUpdateInstant?: number;
+  localizedNames?: LocalizedStrings;
+  modifyEmailTemplateId?: UUID;
+  name?: string;
+  options?: Array<UserActionOption>;
+  preventLogin?: boolean;
+  sendEndEvent?: boolean;
+  startEmailTemplateId?: UUID;
+  temporal?: boolean;
+  transactionType?: TransactionType;
+  userEmailingEnabled?: boolean;
+  userNotificationsEnabled?: boolean;
+}
+
+/**
+ * Models the user action Event.
+ *
+ * @author Brian Pontarelli
+ */
+export interface UserActionEvent extends BaseEvent {
+  action?: string;
+  actioneeUserId?: UUID;
+  actionerUserId?: UUID;
+  actionId?: UUID;
+  applicationIds?: Array<UUID>;
+  comment?: string;
+  email?: Email;
+  emailedUser?: boolean;
+  expiry?: number;
+  localizedAction?: string;
+  localizedDuration?: string;
+  localizedOption?: string;
+  localizedReason?: string;
+  notifyUser?: boolean;
+  option?: string;
+  phase?: UserActionPhase;
+  reason?: string;
+  reasonCode?: string;
+}
+
+/**
+ * A log for an action that was taken on a User.
+ *
+ * @author Brian Pontarelli
+ */
+export interface UserActionLog {
+  actioneeUserId?: UUID;
+  actionerUserId?: UUID;
+  applicationIds?: Array<UUID>;
+  comment?: string;
+  emailUserOnEnd?: boolean;
+  endEventSent?: boolean;
+  expiry?: number;
+  history?: LogHistory;
+  id?: UUID;
+  insertInstant?: number;
+  localizedName?: string;
+  localizedOption?: string;
+  localizedReason?: string;
+  name?: string;
+  notifyUserOnEnd?: boolean;
+  option?: string;
+  reason?: string;
+  reasonCode?: string;
+  userActionId?: UUID;
+}
+
+/**
+ * Models content user action options.
+ *
+ * @author Brian Pontarelli
+ */
+export interface UserActionOption {
+  localizedNames?: LocalizedStrings;
   name?: string;
 }
 
 /**
- * @author Daniel DeGroff
- */
-export enum VerificationStrategy {
-  ClickableLink = "ClickableLink",
-  FormField = "FormField"
-}
-
-/**
- * This class contains the managed fields that are also put into the database during FusionAuth setup.
- * <p>
- * Internal Note: These fields are also declared in SQL in order to bootstrap the system. These need to stay in sync.
- * Any changes to these fields needs to also be reflected in mysql.sql and postgresql.sql
+ * The phases of a time-based user action.
  *
  * @author Brian Pontarelli
  */
-export interface ManagedFields {
-}
-
-/**
- * Webhook event log search request.
- *
- * @author Spencer Witt
- */
-export interface WebhookEventLogSearchRequest {
-  search?: WebhookEventLogSearchCriteria;
-}
-
-/**
- * @author Daniel DeGroff
- */
-export interface AuthenticatorConfiguration {
-  algorithm?: TOTPAlgorithm;
-  codeLength?: number;
-  timeStep?: number;
-}
-
-export enum TOTPAlgorithm {
-  HmacSHA1 = "HmacSHA1",
-  HmacSHA256 = "HmacSHA256",
-  HmacSHA512 = "HmacSHA512"
+export enum UserActionPhase {
+  start = "start",
+  modify = "modify",
+  cancel = "cancel",
+  end = "end"
 }
 
 /**
@@ -11734,6 +11300,692 @@ export interface UserActionReason {
   lastUpdateInstant?: number;
   localizedTexts?: LocalizedStrings;
   text?: string;
+}
+
+/**
+ * User Action Reason API request object.
+ *
+ * @author Brian Pontarelli
+ */
+export interface UserActionReasonRequest {
+  userActionReason?: UserActionReason;
+}
+
+/**
+ * User Action Reason API response object.
+ *
+ * @author Brian Pontarelli
+ */
+export interface UserActionReasonResponse {
+  userActionReason?: UserActionReason;
+  userActionReasons?: Array<UserActionReason>;
+}
+
+/**
+ * User Action API request object.
+ *
+ * @author Brian Pontarelli
+ */
+export interface UserActionRequest {
+  userAction?: UserAction;
+}
+
+/**
+ * User Action API response object.
+ *
+ * @author Brian Pontarelli
+ */
+export interface UserActionResponse {
+  userAction?: UserAction;
+  userActions?: Array<UserAction>;
+}
+
+/**
+ * Models the User Bulk Create Event.
+ *
+ * @author Brian Pontarelli
+ */
+export interface UserBulkCreateEvent extends BaseEvent {
+  users?: Array<User>;
+}
+
+/**
+ * A log for an event that happened to a User.
+ *
+ * @author Brian Pontarelli
+ */
+export interface UserComment {
+  comment?: string;
+  commenterId?: UUID;
+  id?: UUID;
+  insertInstant?: number;
+  userId?: UUID;
+}
+
+/**
+ * @author Seth Musselman
+ */
+export interface UserCommentRequest {
+  userComment?: UserComment;
+}
+
+/**
+ * User Comment Response
+ *
+ * @author Seth Musselman
+ */
+export interface UserCommentResponse {
+  userComment?: UserComment;
+  userComments?: Array<UserComment>;
+}
+
+/**
+ * Search criteria for user comments.
+ *
+ * @author Spencer Witt
+ */
+export interface UserCommentSearchCriteria extends BaseSearchCriteria {
+  comment?: string;
+  commenterId?: UUID;
+  tenantId?: UUID;
+  userId?: UUID;
+}
+
+/**
+ * Search request for user comments
+ *
+ * @author Spencer Witt
+ */
+export interface UserCommentSearchRequest {
+  search?: UserCommentSearchCriteria;
+}
+
+/**
+ * User comment search response
+ *
+ * @author Spencer Witt
+ */
+export interface UserCommentSearchResponse {
+  total?: number;
+  userComments?: Array<UserComment>;
+}
+
+/**
+ * Models a User consent.
+ *
+ * @author Daniel DeGroff
+ */
+export interface UserConsent {
+  consent?: Consent;
+  consentId?: UUID;
+  data?: Record<string, any>;
+  giverUserId?: UUID;
+  id?: UUID;
+  insertInstant?: number;
+  lastUpdateInstant?: number;
+  status?: ConsentStatus;
+  userId?: UUID;
+  values?: Array<string>;
+}
+
+/**
+ * API response for User consent.
+ *
+ * @author Daniel DeGroff
+ */
+export interface UserConsentRequest {
+  userConsent?: UserConsent;
+}
+
+/**
+ * API response for User consent.
+ *
+ * @author Daniel DeGroff
+ */
+export interface UserConsentResponse {
+  userConsent?: UserConsent;
+  userConsents?: Array<UserConsent>;
+}
+
+/**
+ * Models the User Created Event.
+ * <p>
+ * This is different than the user.create event in that it will be sent after the user has been created. This event cannot be made transactional.
+ *
+ * @author Daniel DeGroff
+ */
+export interface UserCreateCompleteEvent extends BaseUserEvent {
+}
+
+/**
+ * Models the User Create Event.
+ *
+ * @author Brian Pontarelli
+ */
+export interface UserCreateEvent extends BaseUserEvent {
+}
+
+/**
+ * Models the User Deactivate Event.
+ *
+ * @author Brian Pontarelli
+ */
+export interface UserDeactivateEvent extends BaseUserEvent {
+}
+
+/**
+ * Models the User Event (and can be converted to JSON) that is used for all user modifications (create, update,
+ * delete).
+ * <p>
+ * This is different than user.delete because it is sent after the tx is committed, this cannot be transactional.
+ *
+ * @author Daniel DeGroff
+ */
+export interface UserDeleteCompleteEvent extends BaseUserEvent {
+}
+
+/**
+ * Models the User Event (and can be converted to JSON) that is used for all user modifications (create, update,
+ * delete).
+ *
+ * @author Brian Pontarelli
+ */
+export interface UserDeleteEvent extends BaseUserEvent {
+}
+
+/**
+ * User API delete request object.
+ *
+ * @author Daniel DeGroff
+ */
+export interface UserDeleteRequest extends BaseEventRequest {
+  dryRun?: boolean;
+  hardDelete?: boolean;
+  limit?: number;
+  query?: string;
+  queryString?: string;
+  userIds?: Array<UUID>;
+}
+
+/**
+ * User API bulk response object.
+ *
+ * @author Trevor Smith
+ */
+export interface UserDeleteResponse {
+  dryRun?: boolean;
+  hardDelete?: boolean;
+  total?: number;
+  userIds?: Array<UUID>;
+}
+
+/**
+ * User API delete request object for a single user.
+ *
+ * @author Brian Pontarelli
+ */
+export interface UserDeleteSingleRequest extends BaseEventRequest {
+  hardDelete?: boolean;
+}
+
+/**
+ * Models an event where a user's email is updated outside of a forgot / change password workflow.
+ *
+ * @author Daniel DeGroff
+ */
+export interface UserEmailUpdateEvent extends BaseUserEvent {
+  previousEmail?: string;
+}
+
+/**
+ * Models the User Email Verify Event.
+ *
+ * @author Trevor Smith
+ */
+export interface UserEmailVerifiedEvent extends BaseUserEvent {
+}
+
+/**
+ * Models the User Identity Provider Link Event.
+ *
+ * @author Rob Davis
+ */
+export interface UserIdentityProviderLinkEvent extends BaseUserEvent {
+  identityProviderLink?: IdentityProviderLink;
+}
+
+/**
+ * Models the User Identity Provider Unlink Event.
+ *
+ * @author Rob Davis
+ */
+export interface UserIdentityProviderUnlinkEvent extends BaseUserEvent {
+  identityProviderLink?: IdentityProviderLink;
+}
+
+/**
+ * Models the User Login Failed Event.
+ *
+ * @author Daniel DeGroff
+ */
+export interface UserLoginFailedEvent extends BaseUserEvent {
+  applicationId?: UUID;
+  authenticationType?: string;
+  ipAddress?: string;
+  reason?: UserLoginFailedReason;
+}
+
+/**
+ * The reason for the login failure.
+ *
+ * @author Daniel DeGroff
+ */
+export interface UserLoginFailedReason {
+  code?: string;
+  lambdaId?: UUID;
+  lambdaResult?: Errors;
+}
+
+/**
+ * User login failed reason codes.
+ */
+export interface UserLoginFailedReasonCode {
+}
+
+/**
+ * Models an event where a user is being created with an "in-use" login Id (email or username).
+ *
+ * @author Daniel DeGroff
+ */
+export interface UserLoginIdDuplicateOnCreateEvent extends BaseUserEvent {
+  duplicateEmail?: string;
+  duplicateUsername?: string;
+  existing?: User;
+}
+
+/**
+ * Models an event where a user is being updated and tries to use an "in-use" login Id (email or username).
+ *
+ * @author Daniel DeGroff
+ */
+export interface UserLoginIdDuplicateOnUpdateEvent extends UserLoginIdDuplicateOnCreateEvent {
+}
+
+/**
+ * Models the User Login event for a new device (un-recognized)
+ *
+ * @author Daniel DeGroff
+ */
+export interface UserLoginNewDeviceEvent extends UserLoginSuccessEvent {
+}
+
+/**
+ * Models the User Login Success Event.
+ *
+ * @author Daniel DeGroff
+ */
+export interface UserLoginSuccessEvent extends BaseUserEvent {
+  applicationId?: UUID;
+  authenticationType?: string;
+  connectorId?: UUID;
+  identityProviderId?: UUID;
+  identityProviderName?: string;
+  ipAddress?: string;
+}
+
+/**
+ * Models the User Login event that is suspicious.
+ *
+ * @author Daniel DeGroff
+ */
+export interface UserLoginSuspiciousEvent extends UserLoginSuccessEvent {
+  threatsDetected?: Array<AuthenticationThreats>;
+}
+
+/**
+ * Models the User Password Breach Event.
+ *
+ * @author Matthew Altman
+ */
+export interface UserPasswordBreachEvent extends BaseUserEvent {
+}
+
+/**
+ * Models the User Password Reset Send Event.
+ *
+ * @author Daniel DeGroff
+ */
+export interface UserPasswordResetSendEvent extends BaseUserEvent {
+}
+
+/**
+ * Models the User Password Reset Start Event.
+ *
+ * @author Daniel DeGroff
+ */
+export interface UserPasswordResetStartEvent extends BaseUserEvent {
+}
+
+/**
+ * Models the User Password Reset Success Event.
+ *
+ * @author Daniel DeGroff
+ */
+export interface UserPasswordResetSuccessEvent extends BaseUserEvent {
+}
+
+/**
+ * Models the User Password Update Event.
+ *
+ * @author Daniel DeGroff
+ */
+export interface UserPasswordUpdateEvent extends BaseUserEvent {
+}
+
+/**
+ * Models the User Reactivate Event.
+ *
+ * @author Brian Pontarelli
+ */
+export interface UserReactivateEvent extends BaseUserEvent {
+}
+
+/**
+ * User registration information for a single application.
+ *
+ * @author Brian Pontarelli
+ */
+export interface UserRegistration {
+  applicationId?: UUID;
+  authenticationToken?: string;
+  cleanSpeakId?: UUID;
+  data?: Record<string, any>;
+  id?: UUID;
+  insertInstant?: number;
+  lastLoginInstant?: number;
+  lastUpdateInstant?: number;
+  preferredLanguages?: Array<string>;
+  roles?: Array<string>;
+  timezone?: string;
+  tokens?: Record<string, string>;
+  username?: string;
+  usernameStatus?: ContentStatus;
+  verified?: boolean;
+  verifiedInstant?: number;
+}
+
+/**
+ * Models the User Created Registration Event.
+ * <p>
+ * This is different than the user.registration.create event in that it will be sent after the user has been created. This event cannot be made
+ * transactional.
+ *
+ * @author Daniel DeGroff
+ */
+export interface UserRegistrationCreateCompleteEvent extends BaseUserEvent {
+  applicationId?: UUID;
+  registration?: UserRegistration;
+}
+
+/**
+ * Models the User Create Registration Event.
+ *
+ * @author Daniel DeGroff
+ */
+export interface UserRegistrationCreateEvent extends BaseUserEvent {
+  applicationId?: UUID;
+  registration?: UserRegistration;
+}
+
+/**
+ * Models the User Deleted Registration Event.
+ * <p>
+ * This is different than user.registration.delete in that it is sent after the TX has been committed. This event cannot be transactional.
+ *
+ * @author Daniel DeGroff
+ */
+export interface UserRegistrationDeleteCompleteEvent extends BaseUserEvent {
+  applicationId?: UUID;
+  registration?: UserRegistration;
+}
+
+/**
+ * Models the User Delete Registration Event.
+ *
+ * @author Daniel DeGroff
+ */
+export interface UserRegistrationDeleteEvent extends BaseUserEvent {
+  applicationId?: UUID;
+  registration?: UserRegistration;
+}
+
+/**
+ * Models the User Update Registration Event.
+ * <p>
+ * This is different than user.registration.update in that it is sent after this event completes, this cannot be transactional.
+ *
+ * @author Daniel DeGroff
+ */
+export interface UserRegistrationUpdateCompleteEvent extends BaseUserEvent {
+  applicationId?: UUID;
+  original?: UserRegistration;
+  registration?: UserRegistration;
+}
+
+/**
+ * Models the User Update Registration Event.
+ *
+ * @author Daniel DeGroff
+ */
+export interface UserRegistrationUpdateEvent extends BaseUserEvent {
+  applicationId?: UUID;
+  original?: UserRegistration;
+  registration?: UserRegistration;
+}
+
+/**
+ * Models the User Registration Verified Event.
+ *
+ * @author Trevor Smith
+ */
+export interface UserRegistrationVerifiedEvent extends BaseUserEvent {
+  applicationId?: UUID;
+  registration?: UserRegistration;
+}
+
+/**
+ * User API request object.
+ *
+ * @author Brian Pontarelli
+ */
+export interface UserRequest extends BaseEventRequest {
+  applicationId?: UUID;
+  currentPassword?: string;
+  disableDomainBlock?: boolean;
+  sendSetPasswordEmail?: boolean;
+  skipVerification?: boolean;
+  user?: User;
+}
+
+/**
+ * User API response object.
+ *
+ * @author Brian Pontarelli
+ */
+export interface UserResponse {
+  emailVerificationId?: string;
+  emailVerificationOneTimeCode?: string;
+  registrationVerificationIds?: Record<UUID, string>;
+  registrationVerificationOneTimeCodes?: Record<UUID, string>;
+  token?: string;
+  tokenExpirationInstant?: number;
+  user?: User;
+}
+
+/**
+ * This class is the user query. It provides a build pattern as well as public fields for use on forms and in actions.
+ *
+ * @author Brian Pontarelli
+ */
+export interface UserSearchCriteria extends BaseElasticSearchCriteria {
+}
+
+/**
+ * @author Daniel DeGroff
+ */
+export enum UserState {
+  Authenticated = "Authenticated",
+  AuthenticatedNotRegistered = "AuthenticatedNotRegistered",
+  AuthenticatedNotVerified = "AuthenticatedNotVerified",
+  AuthenticatedRegistrationNotVerified = "AuthenticatedRegistrationNotVerified"
+}
+
+/**
+ * @author Daniel DeGroff
+ */
+export interface UserTwoFactorConfiguration {
+  methods?: Array<TwoFactorMethod>;
+  recoveryCodes?: Array<string>;
+}
+
+/**
+ * Model a user event when a two-factor method has been removed.
+ *
+ * @author Daniel DeGroff
+ */
+export interface UserTwoFactorMethodAddEvent extends BaseUserEvent {
+  method?: TwoFactorMethod;
+}
+
+/**
+ * Model a user event when a two-factor method has been added.
+ *
+ * @author Daniel DeGroff
+ */
+export interface UserTwoFactorMethodRemoveEvent extends BaseUserEvent {
+  method?: TwoFactorMethod;
+}
+
+/**
+ * Models the User Update Event once it is completed. This cannot be transactional.
+ *
+ * @author Daniel DeGroff
+ */
+export interface UserUpdateCompleteEvent extends BaseUserEvent {
+  original?: User;
+}
+
+/**
+ * Models the User Update Event.
+ *
+ * @author Brian Pontarelli
+ */
+export interface UserUpdateEvent extends BaseUserEvent {
+  original?: User;
+}
+
+/**
+ * Used to express whether the Relying Party requires <a href="https://www.w3.org/TR/webauthn-2/#user-verification">user verification</a> for the
+ * current operation.
+ *
+ * @author Spencer Witt
+ */
+export enum UserVerificationRequirement {
+  required = "required",
+  preferred = "preferred",
+  discouraged = "discouraged"
+}
+
+/**
+ * @author Daniel DeGroff
+ */
+export interface UserinfoResponse extends Record<string, any> {
+}
+
+/**
+ * @author Daniel DeGroff
+ */
+export interface ValidateResponse {
+  jwt?: JWT;
+}
+
+/**
+ * @author Daniel DeGroff
+ */
+export enum VerificationStrategy {
+  ClickableLink = "ClickableLink",
+  FormField = "FormField"
+}
+
+/**
+ * @author Daniel DeGroff
+ */
+export interface VerifyEmailRequest extends BaseEventRequest {
+  oneTimeCode?: string;
+  userId?: UUID;
+  verificationId?: string;
+}
+
+/**
+ * @author Daniel DeGroff
+ */
+export interface VerifyEmailResponse {
+  oneTimeCode?: string;
+  verificationId?: string;
+}
+
+/**
+ * @author Daniel DeGroff
+ */
+export interface VerifyRegistrationRequest extends BaseEventRequest {
+  oneTimeCode?: string;
+  verificationId?: string;
+}
+
+/**
+ * @author Daniel DeGroff
+ */
+export interface VerifyRegistrationResponse {
+  oneTimeCode?: string;
+  verificationId?: string;
+}
+
+/**
+ * @author Daniel DeGroff
+ */
+export interface VersionResponse {
+  version?: string;
+}
+
+/**
+ * API response for completing WebAuthn assertion
+ *
+ * @author Spencer Witt
+ */
+export interface WebAuthnAssertResponse {
+  credential?: WebAuthnCredential;
+}
+
+/**
+ * The <i>authenticator's</i> response for the authentication ceremony in its encoded format
+ *
+ * @author Spencer Witt
+ */
+export interface WebAuthnAuthenticatorAuthenticationResponse {
+  authenticatorData?: string;
+  clientDataJSON?: string;
+  signature?: string;
+  userHandle?: string;
+}
+
+/**
+ * The <i>authenticator's</i> response for the registration ceremony in its encoded format
+ *
+ * @author Spencer Witt
+ */
+export interface WebAuthnAuthenticatorRegistrationResponse {
+  attestationObject?: string;
+  clientDataJSON?: string;
 }
 
 /**
@@ -11763,436 +12015,372 @@ export interface WebAuthnCredential {
 }
 
 /**
- * @author Daniel DeGroff
+ * API request to import an existing WebAuthn credential(s)
+ *
+ * @author Spencer Witt
  */
-export interface TestEvent extends BaseEvent {
-  message?: string;
+export interface WebAuthnCredentialImportRequest {
+  credentials?: Array<WebAuthnCredential>;
+  validateDbConstraints?: boolean;
 }
 
 /**
- * Configuration for encrypted assertions when acting as SAML Service Provider
+ * WebAuthn Credential API response
  *
- * @author Jaret Hendrickson
+ * @author Spencer Witt
  */
-export interface SAMLv2AssertionDecryptionConfiguration extends Enableable {
-  keyTransportDecryptionKeyId?: UUID;
+export interface WebAuthnCredentialResponse {
+  credential?: WebAuthnCredential;
+  credentials?: Array<WebAuthnCredential>;
 }
 
 /**
- * Models the Refresh Token Revoke Event. This event might be for a single token, a user
- * or an entire application.
+ * Contains extension output for requested extensions during a WebAuthn ceremony
  *
- * @author Brian Pontarelli
+ * @author Spencer Witt
  */
-export interface JWTRefreshTokenRevokeEvent extends BaseEvent {
-  applicationId?: UUID;
-  applicationTimeToLiveInSeconds?: Record<UUID, number>;
-  refreshToken?: RefreshToken;
-  user?: User;
+export interface WebAuthnExtensionsClientOutputs {
+  credProps?: CredentialPropertiesOutput;
+}
+
+/**
+ * Request to complete the WebAuthn registration ceremony
+ *
+ * @author Spencer Witt
+ */
+export interface WebAuthnLoginRequest extends BaseLoginRequest {
+  credential?: WebAuthnPublicKeyAuthenticationRequest;
+  origin?: string;
+  rpId?: string;
+  twoFactorTrustId?: string;
+}
+
+/**
+ * Request to authenticate with WebAuthn
+ *
+ * @author Spencer Witt
+ */
+export interface WebAuthnPublicKeyAuthenticationRequest {
+  clientExtensionResults?: WebAuthnExtensionsClientOutputs;
+  id?: string;
+  response?: WebAuthnAuthenticatorAuthenticationResponse;
+  rpId?: string;
+  type?: string;
+}
+
+/**
+ * Request to register a new public key with WebAuthn
+ *
+ * @author Spencer Witt
+ */
+export interface WebAuthnPublicKeyRegistrationRequest {
+  clientExtensionResults?: WebAuthnExtensionsClientOutputs;
+  id?: string;
+  response?: WebAuthnAuthenticatorRegistrationResponse;
+  rpId?: string;
+  transports?: Array<string>;
+  type?: string;
+}
+
+/**
+ * Request to complete the WebAuthn registration ceremony for a new credential,.
+ *
+ * @author Spencer Witt
+ */
+export interface WebAuthnRegisterCompleteRequest {
+  credential?: WebAuthnPublicKeyRegistrationRequest;
+  origin?: string;
+  rpId?: string;
   userId?: UUID;
 }
 
 /**
- * @author Trevor Smith
- */
-export interface ConnectorPolicy {
-  connectorId?: UUID;
-  data?: Record<string, any>;
-  domains?: Array<string>;
-  migrate?: boolean;
-}
-
-/**
- * @author Brett Pontarelli
- */
-export enum AuthenticationThreats {
-  ImpossibleTravel = "ImpossibleTravel"
-}
-
-/**
- * Models the User Password Reset Send Event.
- *
- * @author Daniel DeGroff
- */
-export interface UserPasswordResetSendEvent extends BaseUserEvent {
-}
-
-/**
- * Event to indicate kickstart has been successfully completed.
- *
- * @author Daniel DeGroff
- */
-export interface KickstartSuccessEvent extends BaseEvent {
-  instanceId?: UUID;
-}
-
-/**
- * User API delete request object.
- *
- * @author Daniel DeGroff
- */
-export interface UserDeleteRequest extends BaseEventRequest {
-  dryRun?: boolean;
-  hardDelete?: boolean;
-  limit?: number;
-  query?: string;
-  queryString?: string;
-  userIds?: Array<UUID>;
-}
-
-/**
- * @author Brett Guy
- */
-export interface TenantAccessControlConfiguration {
-  uiIPAccessControlListId?: UUID;
-}
-
-/**
- * This class is a simple attachment with a byte array, name and MIME type.
- *
- * @author Brian Pontarelli
- */
-export interface Attachment {
-  attachment?: Array<number>;
-  mime?: string;
-  name?: string;
-}
-
-/**
- * Interface for any object that can provide JSON Web key Information.
- */
-export interface JSONWebKeyInfoProvider {
-}
-
-/**
- * Tenant-level configuration for WebAuthn
+ * API response for completing WebAuthn credential registration or assertion
  *
  * @author Spencer Witt
  */
-export interface TenantWebAuthnConfiguration extends Enableable {
-  bootstrapWorkflow?: TenantWebAuthnWorkflowConfiguration;
-  debug?: boolean;
-  reauthenticationWorkflow?: TenantWebAuthnWorkflowConfiguration;
-  relyingPartyId?: string;
-  relyingPartyName?: string;
+export interface WebAuthnRegisterCompleteResponse {
+  credential?: WebAuthnCredential;
 }
 
 /**
- * Email template request.
+ * API request to start a WebAuthn registration ceremony
  *
- * @author Brian Pontarelli
+ * @author Spencer Witt
  */
-export interface EmailTemplateRequest {
-  emailTemplate?: EmailTemplate;
+export interface WebAuthnRegisterStartRequest {
+  displayName?: string;
+  name?: string;
+  userAgent?: string;
+  userId?: UUID;
+  workflow?: WebAuthnWorkflow;
 }
 
 /**
- * @author Daniel DeGroff
+ * API response for starting a WebAuthn registration ceremony
+ *
+ * @author Spencer Witt
  */
-export interface IdentityProviderPendingLinkResponse {
-  identityProviderTenantConfiguration?: IdentityProviderTenantConfiguration;
-  linkCount?: number;
-  pendingIdPLink?: PendingIdPLink;
+export interface WebAuthnRegisterStartResponse {
+  options?: PublicKeyCredentialCreationOptions;
 }
 
 /**
- * @author Daniel DeGroff
+ * Options to request extensions during credential registration
+ *
+ * @author Spencer Witt
  */
-export interface PasswordlessSendRequest {
+export interface WebAuthnRegistrationExtensionOptions {
+  credProps?: boolean;
+}
+
+/**
+ * API request to start a WebAuthn authentication ceremony
+ *
+ * @author Spencer Witt
+ */
+export interface WebAuthnStartRequest {
   applicationId?: UUID;
-  code?: string;
+  credentialId?: UUID;
   loginId?: string;
   state?: Record<string, any>;
-}
-
-/**
- * @author Daniel DeGroff
- */
-export interface TenantRegistrationConfiguration {
-  blockedDomains?: Array<string>;
-}
-
-/**
- * @author Daniel DeGroff
- */
-export interface IdentityProviderLink {
-  data?: Record<string, any>;
-  displayName?: string;
-  identityProviderId?: UUID;
-  identityProviderName?: string;
-  identityProviderType?: IdentityProviderType;
-  identityProviderUserId?: string;
-  insertInstant?: number;
-  lastLoginInstant?: number;
-  tenantId?: UUID;
-  token?: string;
   userId?: UUID;
+  workflow?: WebAuthnWorkflow;
 }
 
 /**
- * Registration API request object.
+ * API response for starting a WebAuthn authentication ceremony
+ *
+ * @author Spencer Witt
+ */
+export interface WebAuthnStartResponse {
+  options?: PublicKeyCredentialRequestOptions;
+}
+
+/**
+ * Identifies the WebAuthn workflow. This will affect the parameters used for credential creation
+ * and request based on the Tenant configuration.
+ *
+ * @author Spencer Witt
+ */
+export enum WebAuthnWorkflow {
+  bootstrap = "bootstrap",
+  general = "general",
+  reauthentication = "reauthentication"
+}
+
+/**
+ * A server where events are sent. This includes user action events and any other events sent by FusionAuth.
  *
  * @author Brian Pontarelli
  */
-export interface RegistrationResponse {
-  refreshToken?: string;
-  refreshTokenId?: UUID;
-  registration?: UserRegistration;
-  registrationVerificationId?: string;
-  registrationVerificationOneTimeCode?: string;
-  token?: string;
-  tokenExpirationInstant?: number;
-  user?: User;
-}
-
-/**
- * A role given to a user for a specific application.
- *
- * @author Seth Musselman
- */
-export interface ApplicationRole {
+export interface Webhook {
+  connectTimeout?: number;
+  data?: Record<string, any>;
   description?: string;
+  eventsEnabled?: Record<EventType, boolean>;
+  global?: boolean;
+  headers?: HTTPHeaders;
+  httpAuthenticationPassword?: string;
+  httpAuthenticationUsername?: string;
   id?: UUID;
   insertInstant?: number;
-  isDefault?: boolean;
-  isSuperRole?: boolean;
   lastUpdateInstant?: number;
-  name?: string;
+  readTimeout?: number;
+  signatureConfiguration?: WebhookSignatureConfiguration;
+  sslCertificate?: string;
+  sslCertificateKeyId?: UUID;
+  tenantIds?: Array<UUID>;
+  url?: string;
 }
 
 /**
- * Google social login provider parameters.
+ * A webhook call attempt log.
  *
- * @author Daniel DeGroff
+ * @author Spencer Witt
  */
-export interface GoogleIdentityProviderProperties {
-  api?: string;
-  button?: string;
+export interface WebhookAttemptLog {
+  attemptResult?: WebhookAttemptResult;
+  data?: Record<string, any>;
+  endInstant?: number;
+  id?: UUID;
+  startInstant?: number;
+  webhookCallResponse?: WebhookCallResponse;
+  webhookEventLogId?: UUID;
+  webhookId?: UUID;
 }
 
 /**
- * @author Daniel DeGroff
- */
-export interface JWKSResponse {
-  keys?: Array<JSONWebKey>;
-}
-
-/**
- * Steam API modes.
+ * Webhook attempt log response.
  *
- * @author Daniel DeGroff
+ * @author Spencer Witt
  */
-export enum SteamAPIMode {
-  Public = "Public",
-  Partner = "Partner"
+export interface WebhookAttemptLogResponse {
+  webhookAttemptLog?: WebhookAttemptLog;
 }
 
 /**
- * Lambda API response object.
+ * The possible states of an individual webhook attempt to a single endpoint.
+ *
+ * @author Spencer Witt
+ */
+export enum WebhookAttemptResult {
+  Success = "Success",
+  Failure = "Failure",
+  Unknown = "Unknown"
+}
+
+/**
+ * A webhook call response.
+ *
+ * @author Spencer Witt
+ */
+export interface WebhookCallResponse {
+  exception?: string;
+  statusCode?: number;
+  url?: string;
+}
+
+export interface WebhookEventLog {
+  attempts?: Array<WebhookAttemptLog>;
+  data?: Record<string, any>;
+  event?: EventRequest;
+  eventResult?: WebhookEventResult;
+  eventType?: EventType;
+  failedAttempts?: number;
+  id?: UUID;
+  insertInstant?: number;
+  lastAttemptInstant?: number;
+  lastUpdateInstant?: number;
+  linkedObjectId?: UUID;
+  sequence?: number;
+  successfulAttempts?: number;
+}
+
+/**
+ * The system configuration for Webhook Event Log data.
+ *
+ * @author Spencer Witt
+ */
+export interface WebhookEventLogConfiguration extends Enableable {
+  delete?: DeleteConfiguration;
+}
+
+/**
+ * Webhook event log response.
+ *
+ * @author Spencer Witt
+ */
+export interface WebhookEventLogResponse {
+  webhookEventLog?: WebhookEventLog;
+}
+
+/**
+ * Search criteria for the webhook event log.
+ *
+ * @author Spencer Witt
+ */
+export interface WebhookEventLogSearchCriteria extends BaseSearchCriteria {
+  end?: number;
+  event?: string;
+  eventResult?: WebhookEventResult;
+  eventType?: EventType;
+  start?: number;
+}
+
+/**
+ * Webhook event log search request.
+ *
+ * @author Spencer Witt
+ */
+export interface WebhookEventLogSearchRequest {
+  search?: WebhookEventLogSearchCriteria;
+}
+
+/**
+ * Webhook event log search response.
+ *
+ * @author Spencer Witt
+ */
+export interface WebhookEventLogSearchResponse {
+  total?: number;
+  webhookEventLogs?: Array<WebhookEventLog>;
+}
+
+/**
+ * The possible result states of a webhook event. This tracks the success of the overall webhook transaction according to the {@link TransactionType}
+ * and configured webhooks.
+ *
+ * @author Spencer Witt
+ */
+export enum WebhookEventResult {
+  Failed = "Failed",
+  Running = "Running",
+  Succeeded = "Succeeded"
+}
+
+/**
+ * Webhook API request object.
  *
  * @author Brian Pontarelli
  */
-export interface LambdaResponse {
-  lambda?: Lambda;
-  lambdas?: Array<Lambda>;
+export interface WebhookRequest {
+  webhook?: Webhook;
 }
 
 /**
- * Models the JWT public key Refresh Token Revoke Event. This event might be for a single
- * token, a user or an entire application.
+ * Webhook API response object.
  *
  * @author Brian Pontarelli
  */
-export interface JWTPublicKeyUpdateEvent extends BaseEvent {
-  applicationIds?: Array<UUID>;
+export interface WebhookResponse {
+  webhook?: Webhook;
+  webhooks?: Array<Webhook>;
 }
 
 /**
- * The Integration Request
+ * Search criteria for webhooks.
  *
- * @author Daniel DeGroff
+ * @author Spencer Witt
  */
-export interface IntegrationRequest {
-  integrations?: Integrations;
+export interface WebhookSearchCriteria extends BaseSearchCriteria {
+  description?: string;
+  tenantId?: UUID;
+  url?: string;
+}
+
+/**
+ * Search request for webhooks
+ *
+ * @author Spencer Witt
+ */
+export interface WebhookSearchRequest {
+  search?: WebhookSearchCriteria;
+}
+
+/**
+ * Webhook search response
+ *
+ * @author Spencer Witt
+ */
+export interface WebhookSearchResponse {
+  total?: number;
+  webhooks?: Array<Webhook>;
+}
+
+/**
+ * Configuration for signing webhooks.
+ *
+ * @author Brent Halsey
+ */
+export interface WebhookSignatureConfiguration extends Enableable {
+  signingKeyId?: UUID;
 }
 
 /**
  * @author Brett Pontarelli
  */
-export enum CaptchaMethod {
-  GoogleRecaptchaV2 = "GoogleRecaptchaV2",
-  GoogleRecaptchaV3 = "GoogleRecaptchaV3",
-  HCaptcha = "HCaptcha",
-  HCaptchaEnterprise = "HCaptchaEnterprise"
-}
-
-/**
- * Models the event types that FusionAuth produces.
- *
- * @author Brian Pontarelli
- */
-export enum EventType {
-  JWTPublicKeyUpdate = "jwt.public-key.update",
-  JWTRefreshTokenRevoke = "jwt.refresh-token.revoke",
-  JWTRefresh = "jwt.refresh",
-  AuditLogCreate = "audit-log.create",
-  EventLogCreate = "event-log.create",
-  KickstartSuccess = "kickstart.success",
-  GroupCreate = "group.create",
-  GroupCreateComplete = "group.create.complete",
-  GroupDelete = "group.delete",
-  GroupDeleteComplete = "group.delete.complete",
-  GroupMemberAdd = "group.member.add",
-  GroupMemberAddComplete = "group.member.add.complete",
-  GroupMemberRemove = "group.member.remove",
-  GroupMemberRemoveComplete = "group.member.remove.complete",
-  GroupMemberUpdate = "group.member.update",
-  GroupMemberUpdateComplete = "group.member.update.complete",
-  GroupUpdate = "group.update",
-  GroupUpdateComplete = "group.update.complete",
-  UserAction = "user.action",
-  UserBulkCreate = "user.bulk.create",
-  UserCreate = "user.create",
-  UserCreateComplete = "user.create.complete",
-  UserDeactivate = "user.deactivate",
-  UserDelete = "user.delete",
-  UserDeleteComplete = "user.delete.complete",
-  UserEmailUpdate = "user.email.update",
-  UserEmailVerified = "user.email.verified",
-  UserIdentityProviderLink = "user.identity-provider.link",
-  UserIdentityProviderUnlink = "user.identity-provider.unlink",
-  UserLoginIdDuplicateOnCreate = "user.loginId.duplicate.create",
-  UserLoginIdDuplicateOnUpdate = "user.loginId.duplicate.update",
-  UserLoginFailed = "user.login.failed",
-  UserLoginNewDevice = "user.login.new-device",
-  UserLoginSuccess = "user.login.success",
-  UserLoginSuspicious = "user.login.suspicious",
-  UserPasswordBreach = "user.password.breach",
-  UserPasswordResetSend = "user.password.reset.send",
-  UserPasswordResetStart = "user.password.reset.start",
-  UserPasswordResetSuccess = "user.password.reset.success",
-  UserPasswordUpdate = "user.password.update",
-  UserReactivate = "user.reactivate",
-  UserRegistrationCreate = "user.registration.create",
-  UserRegistrationCreateComplete = "user.registration.create.complete",
-  UserRegistrationDelete = "user.registration.delete",
-  UserRegistrationDeleteComplete = "user.registration.delete.complete",
-  UserRegistrationUpdate = "user.registration.update",
-  UserRegistrationUpdateComplete = "user.registration.update.complete",
-  UserRegistrationVerified = "user.registration.verified",
-  UserTwoFactorMethodAdd = "user.two-factor.method.add",
-  UserTwoFactorMethodRemove = "user.two-factor.method.remove",
-  UserUpdate = "user.update",
-  UserUpdateComplete = "user.update.complete",
-  Test = "test"
-}
-
-/**
- * @author Daniel DeGroff
- */
-export interface PasswordlessStartResponse {
-  code?: string;
-}
-
-/**
- * Policy for handling unknown OAuth scopes in the request
- *
- * @author Spencer Witt
- */
-export enum UnknownScopePolicy {
-  Allow = "Allow",
-  Remove = "Remove",
-  Reject = "Reject"
-}
-
-/**
- * @author Daniel DeGroff
- */
-export interface AppleApplicationConfiguration extends BaseIdentityProviderApplicationConfiguration {
-  bundleId?: string;
-  buttonText?: string;
-  keyId?: UUID;
-  scope?: string;
-  servicesId?: string;
-  teamId?: string;
-}
-
-/**
- * Audit log response.
- *
- * @author Brian Pontarelli
- */
-export interface AuditLogResponse {
-  auditLog?: AuditLog;
-}
-
-/**
- * domain POJO to represent AuthenticationKey
- *
- * @author sanjay
- */
-export interface APIKey {
-  expirationInstant?: number;
-  id?: UUID;
-  insertInstant?: number;
-  ipAccessControlListId?: UUID;
-  key?: string;
-  keyManager?: boolean;
-  lastUpdateInstant?: number;
-  metaData?: APIKeyMetaData;
-  name?: string;
-  permissions?: APIKeyPermissions;
-  retrievable?: boolean;
-  tenantId?: UUID;
-}
-
-export interface APIKeyMetaData {
-  attributes?: Record<string, string>;
-}
-
-export interface APIKeyPermissions {
-  endpoints?: Record<string, Array<string>>;
-}
-
-/**
- * The application's relationship to the authorization server. First-party applications will be granted implicit permission for requested scopes.
- * Third-party applications will use the {@link OAuthScopeConsentMode} policy.
- *
- * @author Spencer Witt
- */
-export enum OAuthApplicationRelationship {
-  FirstParty = "FirstParty",
-  ThirdParty = "ThirdParty"
-}
-
-/**
- * @author Daniel DeGroff
- */
-export interface IdentityProviderOauth2Configuration {
-  authorization_endpoint?: string;
-  client_id?: string;
-  client_secret?: string;
-  clientAuthenticationMethod?: ClientAuthenticationMethod;
-  emailClaim?: string;
-  emailVerifiedClaim?: string;
-  issuer?: string;
-  scope?: string;
-  token_endpoint?: string;
-  uniqueIdClaim?: string;
-  userinfo_endpoint?: string;
-  usernameClaim?: string;
-}
-
-export enum ClientAuthenticationMethod {
-  none = "none",
-  client_secret_basic = "client_secret_basic",
-  client_secret_post = "client_secret_post"
-}
-
-/**
- * @author Daniel DeGroff
- */
-export interface LinkedInIdentityProvider extends BaseIdentityProvider<LinkedInApplicationConfiguration> {
+export interface XboxApplicationConfiguration extends BaseIdentityProviderApplicationConfiguration {
   buttonText?: string;
   client_id?: string;
   client_secret?: string;
@@ -12200,202 +12388,14 @@ export interface LinkedInIdentityProvider extends BaseIdentityProvider<LinkedInA
 }
 
 /**
- * @author Brian Pontarelli
- */
-export interface LoginResponse {
-  actions?: Array<LoginPreventedResponse>;
-  changePasswordId?: string;
-  changePasswordReason?: ChangePasswordReason;
-  configurableMethods?: Array<string>;
-  emailVerificationId?: string;
-  methods?: Array<TwoFactorMethod>;
-  pendingIdPLinkId?: string;
-  refreshToken?: string;
-  refreshTokenId?: UUID;
-  registrationVerificationId?: string;
-  state?: Record<string, any>;
-  threatsDetected?: Array<AuthenticationThreats>;
-  token?: string;
-  tokenExpirationInstant?: number;
-  trustToken?: string;
-  twoFactorId?: string;
-  twoFactorTrustId?: string;
-  user?: User;
-}
-
-/**
- * Models a consent.
+ * Xbox gaming login provider.
  *
- * @author Daniel DeGroff
+ * @author Brett Pontarelli
  */
-export interface Consent {
-  consentEmailTemplateId?: UUID;
-  countryMinimumAgeForSelfConsent?: LocalizedIntegers;
-  data?: Record<string, any>;
-  defaultMinimumAgeForSelfConsent?: number;
-  emailPlus?: EmailPlus;
-  id?: UUID;
-  insertInstant?: number;
-  lastUpdateInstant?: number;
-  multipleValuesAllowed?: boolean;
-  name?: string;
-  values?: Array<string>;
-}
-
-export interface EmailPlus extends Enableable {
-  emailTemplateId?: UUID;
-  maximumTimeToSendEmailInHours?: number;
-  minimumTimeToSendEmailInHours?: number;
-}
-
-/**
- * Base class for all {@link Group} and {@link GroupMember} events.
- *
- * @author Spencer Witt
- */
-export interface BaseGroupEvent extends BaseEvent {
-  group?: Group;
-}
-
-/**
- * Models a specific entity type permission. This permission can be granted to users or other entities.
- *
- * @author Brian Pontarelli
- */
-export interface EntityTypePermission {
-  data?: Record<string, any>;
-  description?: string;
-  id?: UUID;
-  insertInstant?: number;
-  isDefault?: boolean;
-  lastUpdateInstant?: number;
-  name?: string;
-}
-
-/**
- * User comment search response
- *
- * @author Spencer Witt
- */
-export interface UserCommentSearchResponse {
-  total?: number;
-  userComments?: Array<UserComment>;
-}
-
-/**
- * This class is the user query. It provides a build pattern as well as public fields for use on forms and in actions.
- *
- * @author Brian Pontarelli
- */
-export interface UserSearchCriteria extends BaseElasticSearchCriteria {
-}
-
-/**
- * @author Daniel DeGroff
- */
-export interface IdentityProviderRequest {
-  identityProvider?: BaseIdentityProvider<any>;
-}
-
-/**
- * Search criteria for Identity Providers.
- *
- * @author Spencer Witt
- */
-export interface IdentityProviderSearchCriteria extends BaseSearchCriteria {
-  applicationId?: UUID;
-  name?: string;
-  type?: IdentityProviderType;
-}
-
-/**
- * Standard error domain object that can also be used as the response from an API call.
- *
- * @author Brian Pontarelli
- */
-export interface Errors {
-  fieldErrors?: Record<string, Array<Error>>;
-  generalErrors?: Array<Error>;
-}
-
-/**
- * Defines an error.
- *
- * @author Brian Pontarelli
- */
-export interface Error {
-  code?: string;
-  data?: Record<string, any>;
-  message?: string;
-}
-
-/**
- * Available JSON Web Algorithms (JWA) as described in RFC 7518 available for this JWT implementation.
- *
- * @author Daniel DeGroff
- */
-export enum Algorithm {
-  ES256 = "ES256",
-  ES384 = "ES384",
-  ES512 = "ES512",
-  HS256 = "HS256",
-  HS384 = "HS384",
-  HS512 = "HS512",
-  PS256 = "PS256",
-  PS384 = "PS384",
-  PS512 = "PS512",
-  RS256 = "RS256",
-  RS384 = "RS384",
-  RS512 = "RS512",
-  none = "none"
-}
-
-/**
- * JSON Web Token (JWT) as defined by RFC 7519.
- * <pre>
- * From RFC 7519 Section 1. Introduction:
- *    The suggested pronunciation of JWT is the same as the English word "jot".
- * </pre>
- * The JWT is not Thread-Safe and should not be re-used.
- *
- * @author Daniel DeGroff
- */
-export interface JWT {
-  aud?: any;
-  exp?: number;
-  iat?: number;
-  iss?: string;
-  jti?: string;
-  nbf?: number;
-  [otherClaims: string]: any; // Any other fields
-  sub?: string;
-}
-
-/**
- * A JSON Web Key as defined by <a href="https://tools.ietf.org/html/rfc7517#section-4">RFC 7517 JSON Web Key (JWK)
- * Section 4</a> and <a href="https://tools.ietf.org/html/rfc7518">RFC 7518 JSON Web Algorithms (JWA)</a>.
- *
- * @author Daniel DeGroff
- */
-export interface JSONWebKey {
-  alg?: Algorithm;
-  crv?: string;
-  d?: string;
-  dp?: string;
-  dq?: string;
-  e?: string;
-  kid?: string;
-  kty?: KeyType;
-  n?: string;
-  [other: string]: any; // Any other fields
-  p?: string;
-  q?: string;
-  qi?: string;
-  use?: string;
-  x?: string;
-  x5c?: Array<string>;
-  x5t?: string;
-  x5t_S256?: string;
-  y?: string;
+export interface XboxIdentityProvider extends BaseIdentityProvider<XboxApplicationConfiguration> {
+  buttonText?: string;
+  client_id?: string;
+  client_secret?: string;
+  scope?: string;
 }
 


### PR DESCRIPTION
### Issue:
- https://linear.app/fusionauth/issue/ENG-2184/client-code-generation-is-non-deterministic

### Problem:
Every time we touch domain objects, the go and typescript clients get generated in a different order. This makes it impossible to determine what changed in client PRs. Furthermore, the order for a pegged version can vary from one developer to another.

This is a result of the domain objects getting loaded in from directory lists. The client generating freemarker then uses code like `[#list domain as d]` to iterate over them.

### Solution:
Use the updated client builder, which sorts the domain objects by their "class" name (the last real name in a file like `io.fusionauth.domain.Tenant.json`

### Linked PR:
- https://github.com/inversoft/client-library-plugin/pull/3
- https://github.com/inversoft/client-library-plugin/pull/5